### PR TITLE
WMS-136 | Add RenderConfig (Global runtime settings for all components)

### DIFF
--- a/docs/src/Main.elm
+++ b/docs/src/Main.elm
@@ -18,6 +18,7 @@ import Return as R
 import Tables.Stories as Tables
 import Texts as Texts
 import Theme as Theme
+import UI.RenderConfig
 import UIExplorer exposing (Config, UIExplorerProgram, explore, logoFromHtml)
 import UIExplorer.Plugins.Note as Note
 import Utils exposing (story)
@@ -46,9 +47,16 @@ config =
 
 main : UIExplorerProgram Model Msg PluginOptions
 main =
+    let
+        renderConfig =
+            UI.RenderConfig.fromWindow
+                { width = 1920
+                , height = 1080
+                }
+    in
     explore
         config
-        [ Texts.stories
+        [ Texts.stories renderConfig
         , Icons.stories
         , Theme.stories
         , Buttons.stories

--- a/docs/src/Texts.elm
+++ b/docs/src/Texts.elm
@@ -7,23 +7,23 @@ import UI.Text as Text
 import UIExplorer exposing (storiesOf)
 
 
-stories =
+stories renderConfig =
     storiesOf
         "Texts"
         [ ( "Texts"
-          , textsView
+          , textsView renderConfig
           , { note = """
 ```elm
 "Wherever You Will Go"
     |> Text.heading1
-    |> Text.toEl
+    |> Text.toEl renderConfig
 
 \"\"\"
 So lately, been wondering
 Who will be there to take my place?
 \"\"\"
     |> Text.body1
-    |> Text.toEl
+    |> Text.toEl renderConfig
 ```
 
 Futures discussions includes:
@@ -51,15 +51,15 @@ styles =
     ]
 
 
-styleView ( component, label ) =
+styleView renderConfig ( component, label ) =
     label
         |> component
-        |> Text.toEl
+        |> Text.toEl renderConfig
 
 
-textsView content =
+textsView renderConfig content =
     styles
-        |> List.map styleView
+        |> List.map (styleView renderConfig)
         |> Element.column
             [ Element.spacing 20
             ]

--- a/src/UI/RenderConfig.elm
+++ b/src/UI/RenderConfig.elm
@@ -1,0 +1,49 @@
+module UI.RenderConfig exposing (RenderConfig, fromWindow, isMobile, isPortrait)
+
+import Element
+
+
+type alias RenderConfigData =
+    { deviceClass : Element.DeviceClass
+    , deviceOrientation : Element.Orientation
+    }
+
+
+type RenderConfig
+    = RenderConfig RenderConfigData
+
+
+fromWindow : { window | height : Int, width : Int } -> RenderConfig
+fromWindow window =
+    let
+        { class, orientation } =
+            Element.classifyDevice window
+    in
+    { deviceClass = class
+    , deviceOrientation = orientation
+    }
+        |> RenderConfig
+
+
+isMobile : RenderConfig -> Bool
+isMobile (RenderConfig { deviceClass }) =
+    -- TODO: Is Tablet mobile?
+    deviceClass == Element.Phone
+
+
+isPortrait : RenderConfig -> Bool
+isPortrait (RenderConfig { deviceOrientation }) =
+    deviceOrientation == Element.Portrait
+
+
+
+{- -- Future thoughts:
+
+   type RenderStyle
+      = StyleLight
+      | StyleDark
+      | StyleAutoOnSunset -- Too utopic, better to never do
+
+   withStyle: RenderStyle -> RenderConfig -> RenderConfig
+   isDark : DateTime -> RenderConfig -> Bool
+-}

--- a/src/UI/RenderConfig.elm
+++ b/src/UI/RenderConfig.elm
@@ -1,5 +1,16 @@
 module UI.RenderConfig exposing (RenderConfig, fromWindow, isMobile, isPortrait)
 
+{- -- Future thoughts:
+
+   type RenderStyle
+      = StyleLight
+      | StyleDark
+      | StyleAutoOnSunset -- Too utopic, better to never do
+
+   withStyle: RenderStyle -> RenderConfig -> RenderConfig
+   isDark : DateTime -> RenderConfig -> Bool
+-}
+
 import Element
 
 
@@ -27,23 +38,9 @@ fromWindow window =
 
 isMobile : RenderConfig -> Bool
 isMobile (RenderConfig { deviceClass }) =
-    -- TODO: Is Tablet mobile?
     deviceClass == Element.Phone
 
 
 isPortrait : RenderConfig -> Bool
 isPortrait (RenderConfig { deviceOrientation }) =
     deviceOrientation == Element.Portrait
-
-
-
-{- -- Future thoughts:
-
-   type RenderStyle
-      = StyleLight
-      | StyleDark
-      | StyleAutoOnSunset -- Too utopic, better to never do
-
-   withStyle: RenderStyle -> RenderConfig -> RenderConfig
-   isDark : DateTime -> RenderConfig -> Bool
--}

--- a/src/UI/Text.elm
+++ b/src/UI/Text.elm
@@ -19,6 +19,7 @@ module UI.Text exposing
 import Element exposing (Attribute, Element)
 import Element.Font as Font
 import List
+import UI.RenderConfig exposing (RenderConfig, isMobile)
 
 
 type alias Properties =
@@ -106,18 +107,27 @@ overline content =
     Text (Properties content SizeOverline)
 
 
-toEl : Text -> Element msg
-toEl text =
+toEl : RenderConfig -> Text -> Element msg
+toEl cfg text =
     case text of
         Text { content, size } ->
             content
                 |> Element.text
                 |> List.singleton
-                |> Element.paragraph (deskAttributes size)
+                |> Element.paragraph (attributes cfg size)
 
 
 
 -- Internal
+
+
+attributes : RenderConfig -> TextSize -> List (Attribute msg)
+attributes config =
+    if isMobile config then
+        mobileAttributes
+
+    else
+        deskAttributes
 
 
 deskAttributes : TextSize -> List (Attribute msg)
@@ -141,6 +151,73 @@ deskAttributes size =
         SizeHeading4 ->
             [ Font.size 32
             , Font.letterSpacing -1
+            ]
+
+        SizeHeading5 ->
+            [ Font.size 24
+            , Font.letterSpacing 0
+            ]
+
+        SizeHeading6 ->
+            [ Font.size 20
+            , Font.letterSpacing 0.15
+            ]
+
+        SizeSubtitle1 ->
+            [ Font.size 16
+            , Font.letterSpacing 0.2
+            ]
+
+        SizeSubtitle2 ->
+            [ Font.size 14
+            , Font.letterSpacing 0.25
+            ]
+
+        SizeBody1 ->
+            [ Font.size 16
+            , Element.spacing 8
+            , Font.letterSpacing 0.2
+            ]
+
+        SizeBody2 ->
+            [ Font.size 14
+            , Element.spacing 10
+            , Font.letterSpacing 0.25
+            ]
+
+        SizeCaption ->
+            [ Font.size 12
+            , Element.spacing 4
+            , Font.letterSpacing 0.5
+            ]
+
+        SizeOverline ->
+            [ Font.size 10
+            , Font.letterSpacing 2
+            ]
+
+
+mobileAttributes : TextSize -> List (Attribute msg)
+mobileAttributes size =
+    case size of
+        SizeHeading1 ->
+            [ Font.size 56
+            , Font.letterSpacing -2
+            ]
+
+        SizeHeading2 ->
+            [ Font.size 48
+            , Font.letterSpacing -1.5
+            ]
+
+        SizeHeading3 ->
+            [ Font.size 40
+            , Font.letterSpacing -1
+            ]
+
+        SizeHeading4 ->
+            [ Font.size 32
+            , Font.letterSpacing -0.5
             ]
 
         SizeHeading5 ->

--- a/tests/Tests/UI/RenderConfig.elm
+++ b/tests/Tests/UI/RenderConfig.elm
@@ -1,0 +1,130 @@
+module Tests.UI.RenderConfig exposing (tests)
+
+import Expect
+import Test exposing (..)
+import UI.RenderConfig as RenderConfig exposing (RenderConfig)
+
+
+tests : Test
+tests =
+    describe "UI.RenderConfig tests"
+        [ ifMobile
+        , noLongerMobile
+        , ifVeryBig
+        , ifVerySmall
+        , ifPortrait
+        , ifLandscape
+        , ifSquare
+        ]
+
+
+ifMobile : Test
+ifMobile =
+    let
+        window =
+            { width = 599, height = 2000 }
+    in
+    describe "#ifMobile"
+        [ test "this is the maximum size considered mobile" <|
+            \_ ->
+                window
+                    |> RenderConfig.fromWindow
+                    |> RenderConfig.isMobile
+                    |> Expect.equal True
+        ]
+
+
+noLongerMobile : Test
+noLongerMobile =
+    let
+        window =
+            { width = 600, height = 600 }
+    in
+    describe "#noLongerMobile"
+        [ test "this is the mininum non-mobile size" <|
+            \_ ->
+                window
+                    |> RenderConfig.fromWindow
+                    |> RenderConfig.isMobile
+                    |> Expect.equal False
+        ]
+
+
+ifVeryBig : Test
+ifVeryBig =
+    let
+        window =
+            { width = 2560, height = 1080 }
+    in
+    describe "#ifVeryBig"
+        [ test "this is not mobile" <|
+            \_ ->
+                window
+                    |> RenderConfig.fromWindow
+                    |> RenderConfig.isMobile
+                    |> Expect.equal False
+        ]
+
+
+ifVerySmall : Test
+ifVerySmall =
+    let
+        window =
+            { width = 240, height = 480 }
+    in
+    describe "#ifVerySmall"
+        [ test "this is absolutely mobile" <|
+            \_ ->
+                window
+                    |> RenderConfig.fromWindow
+                    |> RenderConfig.isMobile
+                    |> Expect.equal True
+        ]
+
+
+ifPortrait : Test
+ifPortrait =
+    let
+        window =
+            { width = 240, height = 480 }
+    in
+    describe "#ifPortrait"
+        [ test "this is portrait" <|
+            \_ ->
+                window
+                    |> RenderConfig.fromWindow
+                    |> RenderConfig.isPortrait
+                    |> Expect.equal True
+        ]
+
+
+ifLandscape : Test
+ifLandscape =
+    let
+        window =
+            { width = 1024, height = 768 }
+    in
+    describe "#ifLandscape"
+        [ test "this is landscape" <|
+            \_ ->
+                window
+                    |> RenderConfig.fromWindow
+                    |> RenderConfig.isPortrait
+                    |> Expect.equal False
+        ]
+
+
+ifSquare : Test
+ifSquare =
+    let
+        window =
+            { width = 1024, height = 768 }
+    in
+    describe "#ifSquare"
+        [ test "a square is landscape" <|
+            \_ ->
+                window
+                    |> RenderConfig.fromWindow
+                    |> RenderConfig.isPortrait
+                    |> Expect.equal False
+        ]


### PR DESCRIPTION
Requires #2 

What this PR does?:
* Add a property to AppConfig that dictates global details about rendering components.
* It can be used to determine responsive constraints at runtime.
* In the future, it can be used for things like dynamic dark-mode.

Missing:
* Obtain real window's width and height in paack-ui's docs!
* Documents on how to initialize and use.