### PR TITLE
Fix full width button

### DIFF
--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -458,8 +458,10 @@ elFromBody cfg body =
                 [ Font.size 16
                 , Element.spacing 8
                 , Font.semiBold
+                , Element.centerX
                 ]
                 (Element.text str)
 
         BodyIcon icon ->
-            Icon.toEl cfg icon
+            Element.el [ Element.centerX ]
+                (Icon.toEl cfg icon)


### PR DESCRIPTION
Centralize text when the button is in full-width mode

### Before

![Screenshot 2020-05-13 at 19 14 55](https://user-images.githubusercontent.com/1559013/81843696-440e5880-954e-11ea-8553-9f5bd8681f73.png)

### After

![Screenshot 2020-05-13 at 19 14 34](https://user-images.githubusercontent.com/1559013/81843698-44a6ef00-954e-11ea-9646-67a201d39b98.png)

