### PR TITLE
Update dialog

### DIFF
--- a/src/UI/Internal/Dialog.elm
+++ b/src/UI/Internal/Dialog.elm
@@ -57,10 +57,14 @@ view cfg { title, body, close, width } =
                         , Element.alignTop
                         ]
                 , Icon.close "Close dialog"
-                    |> Button.bodyIcon
-                    |> Button.button close
-                    |> Button.withTone Button.toneClear
-                    |> Button.toEl cfg
+                    |> Icon.toEl cfg
+                    |> Element.el
+                        [ Events.onClick close
+                        , Element.pointer
+                        , Element.width (px 20)
+                        , Element.paddingXY 23 20
+                        , ARIA.roleAttr ARIA.roleButton
+                        ]
                 ]
     in
     Element.column


### PR DESCRIPTION
This PR:
* Update dialog padding to match Zeplin
* ~Use `<Button:ToneClear>` instead of `Icon`, this way padding and aria-helpers are concise.~ (REVERTED)
* Fix an width issue where `row > collumn` was rendered as `div > s > div` and the `s` element wasn't properly respecting `width:100%` rule. For this, the `row` was replaced with a simpler `el`

Required changes in parent projects:
* Remove padding in dialog's body element.