### PR TITLE
WMS-399 | Fix ellipsis behaviour

### DIFF
--- a/src/UI/Internal/Text.elm
+++ b/src/UI/Internal/Text.elm
@@ -3,7 +3,6 @@ module UI.Internal.Text exposing (..)
 import Element exposing (Attribute, Element, fill)
 import Element.Font as Font
 import Html
-import Html.Attributes
 import List
 import UI.Internal.Basics exposing (ifThenElse)
 import UI.Internal.Palette as Palette

--- a/src/UI/Internal/Text.elm
+++ b/src/UI/Internal/Text.elm
@@ -6,6 +6,7 @@ import Html
 import List
 import UI.Internal.Basics exposing (ifThenElse)
 import UI.Internal.Palette as Palette
+import UI.Internal.Utils.Element exposing (tuplesToStyles)
 import UI.Palette as Palette exposing (brightnessDarkest, toneGray)
 import UI.RenderConfig exposing (RenderConfig, isMobile)
 import UI.Utils.Element as Element
@@ -104,7 +105,7 @@ attributes config size ellipsis color =
             else
                 deskAttributes size
 
-        ellipsisAttrs attrs =
+        heightAttr attrs =
             if ellipsis then
                 oneLineHeight mobile size :: attrs
 
@@ -120,7 +121,7 @@ attributes config size ellipsis color =
                     attrs
     in
     sizeAttrs
-        |> ellipsisAttrs
+        |> heightAttr
         |> colorAttr
 
 
@@ -336,7 +337,7 @@ spanMapOptions applier (Span prop opt) =
 spanRenderEl : RenderConfig -> Span -> Element msg
 spanRenderEl cfg (Span { content, size } { color, oneLineEllipsis }) =
     content
-        |> ifThenElse oneLineEllipsis ellipsizedText Element.text
+        |> ifThenElse oneLineEllipsis (ellipsizedText cfg size) Element.text
         |> List.singleton
         |> Element.paragraph
             (attributes cfg size oneLineEllipsis color)
@@ -368,9 +369,26 @@ combinedAttrs { ellipsis } =
         []
 
 
-ellipsizedText : String -> Element msg
-ellipsizedText content =
+ellipsizedText : RenderConfig -> TextSize -> String -> Element msg
+ellipsizedText cfg size content =
+    let
+        lineHeightSize =
+            lineHeight (isMobile cfg) size
+    in
     content
         |> Html.text
         |> Element.html
-        |> Element.el Element.ellipsis
+        |> Element.el
+            (ellipsisAttrs lineHeightSize)
+
+
+ellipsisAttrs : Int -> List (Attribute msg)
+ellipsisAttrs lineHeightSize =
+    [ ( "text-overflow", "ellipsis" )
+    , ( "white-space", "nowrap" )
+    , ( "overflow", "hidden" )
+    , ( "display", "block" )
+    , ( "line-height", String.fromInt lineHeightSize ++ "px" )
+    ]
+        |> List.map tuplesToStyles
+        |> (::) Element.clip

--- a/src/UI/Internal/Text.elm
+++ b/src/UI/Internal/Text.elm
@@ -6,7 +6,7 @@ import Html
 import List
 import UI.Internal.Basics exposing (ifThenElse)
 import UI.Internal.Palette as Palette
-import UI.Internal.Utils.Element exposing (tuplesToStyles)
+import UI.Internal.Utils.Element exposing (ellipsisAttrs)
 import UI.Palette as Palette exposing (brightnessDarkest, toneGray)
 import UI.RenderConfig exposing (RenderConfig, isMobile)
 import UI.Utils.Element as Element
@@ -380,15 +380,3 @@ ellipsizedText cfg size content =
         |> Element.html
         |> Element.el
             (ellipsisAttrs lineHeightSize)
-
-
-ellipsisAttrs : Int -> List (Attribute msg)
-ellipsisAttrs lineHeightSize =
-    [ ( "text-overflow", "ellipsis" )
-    , ( "white-space", "nowrap" )
-    , ( "overflow", "hidden" )
-    , ( "display", "block" )
-    , ( "line-height", String.fromInt lineHeightSize ++ "px" )
-    ]
-        |> List.map tuplesToStyles
-        |> (::) Element.clip

--- a/src/UI/Internal/Text.elm
+++ b/src/UI/Internal/Text.elm
@@ -2,6 +2,8 @@ module UI.Internal.Text exposing (..)
 
 import Element exposing (Attribute, Element, fill)
 import Element.Font as Font
+import Html
+import Html.Attributes
 import List
 import UI.Internal.Basics exposing (ifThenElse)
 import UI.Internal.Palette as Palette
@@ -105,7 +107,7 @@ attributes config size ellipsis color =
 
         ellipsisAttrs attrs =
             if ellipsis then
-                (oneLineHeight mobile size :: Element.ellipsis) ++ attrs
+                oneLineHeight mobile size :: attrs
 
             else
                 attrs
@@ -335,7 +337,7 @@ spanMapOptions applier (Span prop opt) =
 spanRenderEl : RenderConfig -> Span -> Element msg
 spanRenderEl cfg (Span { content, size } { color, oneLineEllipsis }) =
     content
-        |> Element.text
+        |> ifThenElse oneLineEllipsis ellipsizedText Element.text
         |> List.singleton
         |> Element.paragraph
             (attributes cfg size oneLineEllipsis color)
@@ -365,3 +367,11 @@ combinedAttrs { ellipsis } =
 
     else
         []
+
+
+ellipsizedText : String -> Element msg
+ellipsizedText content =
+    content
+        |> Html.text
+        |> Element.html
+        |> Element.el Element.ellipsis

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -1,0 +1,14 @@
+module UI.Internal.Utils.Element exposing (style, tuplesToStyles)
+
+import Element exposing (Attribute)
+import Html.Attributes as HtmlAttrs
+
+
+style : String -> String -> Attribute msg
+style k v =
+    Element.htmlAttribute <| HtmlAttrs.style k v
+
+
+tuplesToStyles : ( String, String ) -> Attribute msg
+tuplesToStyles ( k, v ) =
+    Element.htmlAttribute <| HtmlAttrs.style k v

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -1,4 +1,4 @@
-module UI.Internal.Utils.Element exposing (style, tuplesToStyles)
+module UI.Internal.Utils.Element exposing (ellipsisAttrs, style, tuplesToStyles)
 
 import Element exposing (Attribute)
 import Html.Attributes as HtmlAttrs
@@ -12,3 +12,15 @@ style k v =
 tuplesToStyles : ( String, String ) -> Attribute msg
 tuplesToStyles ( k, v ) =
     Element.htmlAttribute <| HtmlAttrs.style k v
+
+
+ellipsisAttrs : Int -> List (Attribute msg)
+ellipsisAttrs lineHeightSize =
+    [ ( "text-overflow", "ellipsis" )
+    , ( "white-space", "nowrap" )
+    , ( "overflow", "hidden" )
+    , ( "display", "block" )
+    , ( "line-height", String.fromInt lineHeightSize ++ "px" )
+    ]
+        |> List.map tuplesToStyles
+        |> (::) Element.clip

--- a/src/UI/Utils/Element.elm
+++ b/src/UI/Utils/Element.elm
@@ -1,7 +1,7 @@
 module UI.Utils.Element exposing
     ( colorSetOpacity, colorTransition
     , desktopMaximum
-    , svg, title, ellipsis, maxHeightVH, maxHeightPct
+    , svg, title, maxHeightVH, maxHeightPct
     , disabled, onEnterPressed, onIndividualClick
     , RectangleSides, zeroPadding
     )
@@ -21,7 +21,7 @@ module UI.Utils.Element exposing
 
 # HTML features
 
-@docs svg, title, ellipsis, maxHeightVH, maxHeightPct
+@docs svg, title, maxHeightVH, maxHeightPct
 
 
 # Input
@@ -40,6 +40,7 @@ import Html.Attributes as HtmlAttrs
 import Html.Events as HtmlEvents
 import Json.Decode as Decode
 import Svg
+import UI.Internal.Utils.Element exposing (style, tuplesToStyles)
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
 import UI.Utils.ARIA as ARIA
 
@@ -97,7 +98,7 @@ colorTransition time =
     , ( "transition-duration", String.fromInt time ++ "ms" )
     , ( "transition-timing-function", "linear" )
     ]
-        |> List.map stylePair
+        |> List.map tuplesToStyles
 
 
 {-| Trigger message when the users press return-key while element is on-focus.
@@ -168,24 +169,6 @@ colorSetOpacity alpha color =
         |> Element.fromRgb
 
 
-{-| Applies required CSS values to have ellipsis on an element's text when width is not enough for displaying the whole content.
-
-    Element.el
-        (Element.width (px 200) :: Element.ellipsis)
-        (Element.text "Lorem ipsum dolor sit amet, consectetur adipiscing elit")
-
--}
-ellipsis : List (Attribute msg)
-ellipsis =
-    [ ( "text-overflow", "ellipsis" )
-    , ( "white-space", "nowrap" )
-    , ( "overflow", "hidden" )
-    , ( "display", "block" )
-    ]
-        |> List.map stylePair
-        |> (::) Element.clip
-
-
 {-| Limit [`Element.fill`](/packages/mdgriffith/elm-ui/latest/Element#fill) only when on desktop.
 
     Element.width (Element.desktopMaximum 640)
@@ -228,17 +211,3 @@ onIndividualClick message =
         |> Decode.map (\msg -> { message = msg, stopPropagation = True, preventDefault = True })
         |> HtmlEvents.custom "click"
         |> Element.htmlAttribute
-
-
-
--- Helpers
-
-
-style : String -> String -> Attribute msg
-style k v =
-    Element.htmlAttribute <| HtmlAttrs.style k v
-
-
-stylePair : ( String, String ) -> Attribute msg
-stylePair ( k, v ) =
-    Element.htmlAttribute <| HtmlAttrs.style k v

--- a/src/UI/Utils/Element.elm
+++ b/src/UI/Utils/Element.elm
@@ -179,6 +179,8 @@ ellipsis : List (Attribute msg)
 ellipsis =
     [ ( "text-overflow", "ellipsis" )
     , ( "white-space", "nowrap" )
+    , ( "overflow", "hidden" )
+    , ( "display", "block" )
     ]
         |> List.map stylePair
         |> (::) Element.clip


### PR DESCRIPTION
So apparently, the ellipsis feature was not working properly, I'm not sure if ever did taking into account this issue opened: [Click here](https://github.com/mdgriffith/elm-ui/issues/49).

Before: 

![Screenshot 2020-07-23 at 19 53 42](https://user-images.githubusercontent.com/1559013/88321215-13e9ef80-cd1f-11ea-8473-bd50a8a1c8fd.png)

After

![Screenshot 2020-07-23 at 19 54 14](https://user-images.githubusercontent.com/1559013/88321180-09c7f100-cd1f-11ea-8887-925b5b16575d.png)

It's quite hackish, but blame elm-ui :o 