### PR TITLE
WMS-438 | Allow custom element table cells

### DIFF
--- a/showcase/src/Tables/Stories.elm
+++ b/showcase/src/Tables/Stories.elm
@@ -193,8 +193,12 @@ tableColumns =
 
 
 toTableRow renderConfig { author, title, year, acquired, read } =
+    let
+        titleCell =
+            Element.el [ underline, italic ] <| Text.renderElement renderConfig <| Text.body2 title
+    in
     rowEmpty
-        |> rowCellCustom (Element.el [ underline, italic ] <| Text.renderElement renderConfig <| Text.body2 title)
+        |> rowCellCustom titleCell
         |> rowCellText (Text.body2 author)
         |> rowCellText (Text.caption year)
         |> rowCellText (Text.caption <| DateInput.toDD_MM_YYYY "/" <| DateInput.fromPosix Time.utc acquired)

--- a/showcase/src/Tables/Stories.elm
+++ b/showcase/src/Tables/Stories.elm
@@ -1,7 +1,7 @@
 module Tables.Stories exposing (stories, update)
 
 import Element exposing (Element, fill)
-import Element.Font exposing(underline, italic)
+import Element.Font exposing (italic, underline)
 import Msg
 import PluginOptions exposing (defaultWithMenu)
 import Return as R exposing (Return)
@@ -194,7 +194,7 @@ tableColumns =
 
 toTableRow renderConfig { author, title, year, acquired, read } =
     rowEmpty
-        |> rowCellCustom (Element.el [underline, italic] <| Text.renderElement renderConfig <| Text.body2 title)
+        |> rowCellCustom (Element.el [ underline, italic ] <| Text.renderElement renderConfig <| Text.body2 title)
         |> rowCellText (Text.body2 author)
         |> rowCellText (Text.caption year)
         |> rowCellText (Text.caption <| DateInput.toDD_MM_YYYY "/" <| DateInput.fromPosix Time.utc acquired)

--- a/showcase/src/Tables/Stories.elm
+++ b/showcase/src/Tables/Stories.elm
@@ -1,6 +1,7 @@
 module Tables.Stories exposing (stories, update)
 
 import Element exposing (Element, fill)
+import Element.Font exposing(underline, italic)
 import Msg
 import PluginOptions exposing (defaultWithMenu)
 import Return as R exposing (Return)
@@ -92,7 +93,7 @@ demoTable renderConfig model =
     Stateful.table
         { toExternalMsg = Stories.ForComponent >> Msg.TablesStoriesMsg
         , columns = tableColumns
-        , toRow = toTableRow
+        , toRow = toTableRow renderConfig
         , state = model.tableState
         }
         |> Stateful.withResponsive
@@ -129,7 +130,7 @@ statelessTableStory renderConfig =
 statelessDemoTable renderConfig =
     Stateless.table
         { columns = tableColumns
-        , toRow = toTableRow
+        , toRow = toTableRow renderConfig
         }
         |> Stateless.withWidth Element.shrink
         |> Stateless.withItems books
@@ -191,9 +192,9 @@ tableColumns =
         |> column "Read" (columnWidthPixels 180)
 
 
-toTableRow { author, title, year, acquired, read } =
+toTableRow renderConfig { author, title, year, acquired, read } =
     rowEmpty
-        |> rowCellText (Text.body1 title)
+        |> rowCellCustom (Element.el [underline, italic] <| Text.renderElement renderConfig <| Text.body2 title)
         |> rowCellText (Text.body2 author)
         |> rowCellText (Text.caption year)
         |> rowCellText (Text.caption <| DateInput.toDD_MM_YYYY "/" <| DateInput.fromPosix Time.utc acquired)

--- a/src/UI/Internal/Tables/Common.elm
+++ b/src/UI/Internal/Tables/Common.elm
@@ -22,4 +22,4 @@ type ColumnWidth
 type Cell msg
     = CellText Text
     | CellButton (Button msg)
-    | Custom (Element msg)
+    | CellCustom (Element msg)

--- a/src/UI/Internal/Tables/Common.elm
+++ b/src/UI/Internal/Tables/Common.elm
@@ -1,5 +1,6 @@
 module UI.Internal.Tables.Common exposing (..)
 
+import Element exposing (Element)
 import UI.Button exposing (Button)
 import UI.Text exposing (Text)
 
@@ -21,3 +22,4 @@ type ColumnWidth
 type Cell msg
     = CellText Text
     | CellButton (Button msg)
+    | Custom (Element msg)

--- a/src/UI/Internal/Tables/View.elm
+++ b/src/UI/Internal/Tables/View.elm
@@ -29,7 +29,7 @@ cellContentRender renderConfig cell_ =
         CellButton button ->
             Button.renderElement renderConfig button
 
-        Custom element ->
+        CellCustom element ->
             element
 
 

--- a/src/UI/Internal/Tables/View.elm
+++ b/src/UI/Internal/Tables/View.elm
@@ -29,6 +29,9 @@ cellContentRender renderConfig cell_ =
         CellButton button ->
             Button.renderElement renderConfig button
 
+        Custom element ->
+            element
+
 
 widthToEl : Common.ColumnWidth -> Element.Length
 widthToEl width =

--- a/src/UI/Tables/Common.elm
+++ b/src/UI/Tables/Common.elm
@@ -143,7 +143,9 @@ cellFromButton text =
 
 
 {-| Creates a cell with an `Element msg` inside.
-    cellFromCustom <| Element.row [] [Element.text "Hello", Element.text "World"]
+
+    cellFromCustom <| Element.row [] [ Element.text "Hello", Element.text "World" ]
+
 -}
 cellFromCustom : Element msg -> Cell msg
 cellFromCustom element =

--- a/src/UI/Tables/Common.elm
+++ b/src/UI/Tables/Common.elm
@@ -3,6 +3,7 @@ module UI.Tables.Common exposing
     , ColumnWidth, columnWidthPortion, columnWidthPixels
     , Row, ToRow, rowEmpty, rowCellText, rowCellButton
     , Cell, cellFromText, cellFromButton
+    , cellFromCustom, rowCellCustom
     )
 
 {-|
@@ -29,6 +30,7 @@ module UI.Tables.Common exposing
 
 -}
 
+import Element exposing (Element)
 import UI.Button exposing (Button)
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Internal.Tables.Common as Internal exposing (..)
@@ -112,7 +114,7 @@ columnWidthPixels value =
 
 
 {-| A singular cell of a table.
-Can hold texts and buttons by now.
+Can hold texts, buttons or any custom `Element msg`.
 -}
 type alias Cell msg =
     Internal.Cell msg
@@ -138,6 +140,14 @@ cellFromText text =
 cellFromButton : Button msg -> Cell msg
 cellFromButton text =
     CellButton text
+
+
+{-| Creates a cell with an `Element msg` inside.
+    cellFromCustom <| Element.row [] [Element.text "Hello", Element.text "World"]
+-}
+cellFromCustom : Element msg -> Cell msg
+cellFromCustom element =
+    Custom element
 
 
 
@@ -203,3 +213,17 @@ Similar to [`cellFromButton`](#cellFromButton) but infused for rows.
 rowCellButton : Button msg -> Row msg columns -> Row msg (T.Increase columns)
 rowCellButton btn accu =
     NArray.push (CellButton btn) accu
+
+
+{-| Transforms any `Element msg` into a cell appending it to a row.
+
+Similar to [`cellFromCustom`](#cellFromCustom) but infused for rows.
+
+    rowEmpty
+        |> rowCellText (Text.body1 "Aldebaran")
+        |> rowCellCustom (Element.text "Hello")
+
+-}
+rowCellCustom : Element msg -> Row msg columns -> Row msg (T.Increase columns)
+rowCellCustom element accu =
+    NArray.push (Custom element) accu

--- a/src/UI/Tables/Common.elm
+++ b/src/UI/Tables/Common.elm
@@ -1,9 +1,8 @@
 module UI.Tables.Common exposing
     ( Columns, columnsEmpty, column
     , ColumnWidth, columnWidthPortion, columnWidthPixels
-    , Row, ToRow, rowEmpty, rowCellText, rowCellButton
-    , Cell, cellFromText, cellFromButton
-    , cellFromCustom, rowCellCustom
+    , Row, ToRow, rowEmpty, rowCellText, rowCellButton, rowCellCustom
+    , Cell, cellFromText, cellFromButton, cellFromCustom
     )
 
 {-|
@@ -21,12 +20,12 @@ module UI.Tables.Common exposing
 
 ## Desktop rows
 
-@docs Row, ToRow, rowEmpty, rowCellText, rowCellButton
+@docs Row, ToRow, rowEmpty, rowCellText, rowCellButton, rowCellCustom
 
 
 # Individual cell
 
-@docs Cell, cellFromText, cellFromButton
+@docs Cell, cellFromText, cellFromButton, cellFromCustom
 
 -}
 

--- a/src/UI/Tables/Common.elm
+++ b/src/UI/Tables/Common.elm
@@ -149,7 +149,7 @@ cellFromButton text =
 -}
 cellFromCustom : Element msg -> Cell msg
 cellFromCustom element =
-    Custom element
+    CellCustom element
 
 
 
@@ -228,4 +228,4 @@ Similar to [`cellFromCustom`](#cellFromCustom) but infused for rows.
 -}
 rowCellCustom : Element msg -> Row msg columns -> Row msg (T.Increase columns)
 rowCellCustom element accu =
-    NArray.push (Custom element) accu
+    NArray.push (CellCustom element) accu


### PR DESCRIPTION
#### :thinking: What?
Previously we could only render a button or text in table cells, this change will allow rendering any custom element.


#### :man_shrugging: Why?
[WMS-416](https://paacklogistics.atlassian.net/browse/WMS-416) needs to render a badge inside a cell, and waiting on this change to get merged.


#### :pushpin: Jira Issue
[WMS-438](https://paacklogistics.atlassian.net/browse/WMS-438)


#### :no_good: Blocked by
None