### PR TITLE
Add min width to portion cells and examples

### DIFF
--- a/cypress/integration/visual-regression.spec.js
+++ b/cypress/integration/visual-regression.spec.js
@@ -64,9 +64,26 @@ describe('Percy Snapshots', () => {
   })
 
   describe('Complex components', () => {
-    it('Creates the Tables page snapshot', () => {
-      cy.visit('/#Complex%20components/Tables/Desktop')
-      cy.percySnapshot('Tables')
+    describe('Tables', () => {
+      it('Creates the Desktop Tables page snapshot', () => {
+        cy.visit('/#Complex%20components/Tables/Desktop')
+        cy.percySnapshot('Tables Desktop')
+      })
+
+      it('Creates the Mobile Tables page snapshot', () => {
+        cy.visit('/#Complex%20components/Tables/Mobile')
+        cy.percySnapshot('Tables Mobile')
+      })
+
+      it('Creates the Stateless Tables page snapshot', () => {
+        cy.visit('/#Complex%20components/Tables/Stateless')
+        cy.percySnapshot('Tables Stateless')
+      })
+
+      it('Creates the Portion Column Tables page snapshot', () => {
+        cy.visit('/#Complex%20components/Tables/Portion%20Column')
+        cy.percySnapshot('Tables Portion Column')
+      })
     })
 
     it('Creates the Paginators page snapshot', () => {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@percy/cypress": "^2.3.1",
     "cypress": "^4.12.1",
+    "elm-format": "^0.8.3",
     "i18n-json-to-elm": "PedroHLC/i18n-json-to-elm"
   }
 }

--- a/showcase/src/Tables/Book.elm
+++ b/showcase/src/Tables/Book.elm
@@ -111,13 +111,22 @@ books =
     ]
 
 
-tableColumns =
+tablePixelColumns =
     columnsEmpty
         |> column "Title" (columnWidthPixels 320)
         |> column "Author" (columnWidthPixels 160)
         |> column "Year" (columnWidthPixels 120)
         |> column "Acquired" (columnWidthPixels 180)
         |> column "Read" (columnWidthPixels 180)
+
+
+tablePortionColumns =
+    columnsEmpty
+        |> column "Title" (columnWidthPortion 20)
+        |> column "Author" (columnWidthPortion 10)
+        |> column "Year" (columnWidthPortion 8)
+        |> column "Acquired" (columnWidthPortion 12)
+        |> column "Read" (columnWidthPortion 12)
 
 
 toTableRow renderConfig { author, title, year, acquired, read } =

--- a/showcase/src/Tables/Stories.elm
+++ b/showcase/src/Tables/Stories.elm
@@ -115,7 +115,15 @@ statelessDemoTable renderConfig =
 selectableTableStory renderConfig =
     storyWithModel
         ( "Selectable"
-        , \{ tablesStories } -> withIcons renderConfig (demoTable renderConfig Book.tablePixelColumns tablesStories.selecTableState Stories.ForSelectable)
+        , \{ tablesStories } ->
+            withIcons
+                renderConfig
+                (demoTable
+                    renderConfig
+                    Book.tablePixelColumns
+                    tablesStories.selecTableState
+                    Stories.ForSelectable
+                )
         , { defaultWithMenu
             | note = "See [docs](https://package.elm-lang.org/packages/PaackEng/paack-ui/latest/UI-Tables-Stateful) for the exact code of this example."
           }
@@ -125,7 +133,15 @@ selectableTableStory renderConfig =
 portionColumnsTable renderConfig =
     storyWithModel
         ( "Portion Columns"
-        , \{ tablesStories } -> withIcons renderConfig (demoTable renderConfig Book.tablePortionColumns tablesStories.selecTableState Stories.ForSelectable)
+        , \{ tablesStories } ->
+            withIcons
+                renderConfig
+                (demoTable
+                    renderConfig
+                    Book.tablePortionColumns
+                    tablesStories.selecTableState
+                    Stories.ForSelectable
+                )
         , { defaultWithMenu
             | note = "See [docs](https://package.elm-lang.org/packages/PaackEng/paack-ui/latest/UI-Tables-Stateful) for the exact code of this example."
           }

--- a/showcase/src/Tables/Stories.elm
+++ b/showcase/src/Tables/Stories.elm
@@ -41,13 +41,14 @@ stories renderConfig =
         , mobileTableStory renderConfig
         , statelessTableStory renderConfig
         , selectableTableStory renderConfig
+        , portionColumnsTable renderConfig
         ]
 
 
 desktopTableStory renderConfig =
     storyWithModel
         ( "Desktop"
-        , \{ tablesStories } -> withIcons renderConfig (demoTable renderConfig tablesStories.mainTableState Stories.ForMain)
+        , \{ tablesStories } -> withIcons renderConfig (demoTable renderConfig Book.tablePixelColumns tablesStories.mainTableState Stories.ForMain)
         , { defaultWithMenu
             | note = "See [docs](https://package.elm-lang.org/packages/PaackEng/paack-ui/latest/UI-Tables-Stateful) for the exact code of this example."
           }
@@ -57,17 +58,17 @@ desktopTableStory renderConfig =
 mobileTableStory renderConfig =
     storyWithModel
         ( "Mobile"
-        , \{ tablesStories } -> withIcons mobileCfg (demoTable renderConfig tablesStories.mainTableState Stories.ForMain)
+        , \{ tablesStories } -> withIcons mobileCfg (demoTable renderConfig Book.tablePixelColumns tablesStories.mainTableState Stories.ForMain)
         , { defaultWithMenu
             | note = "See [docs](https://package.elm-lang.org/packages/PaackEng/paack-ui/latest/UI-Tables-Stateful) for the exact code of this example."
           }
         )
 
 
-demoTable renderConfig state msg =
+demoTable renderConfig columns state msg =
     Stateful.table
         { toExternalMsg = msg >> Msg.TablesStoriesMsg
-        , columns = Book.tableColumns
+        , columns = columns
         , toRow = Book.toTableRow renderConfig
         , state = state
         }
@@ -103,7 +104,7 @@ statelessTableStory renderConfig =
 
 statelessDemoTable renderConfig =
     Stateless.table
-        { columns = Book.tableColumns
+        { columns = Book.tablePixelColumns
         , toRow = Book.toTableRow renderConfig
         }
         |> Stateless.withWidth Element.shrink
@@ -114,7 +115,17 @@ statelessDemoTable renderConfig =
 selectableTableStory renderConfig =
     storyWithModel
         ( "Selectable"
-        , \{ tablesStories } -> withIcons renderConfig (demoTable renderConfig tablesStories.selecTableState Stories.ForSelectable)
+        , \{ tablesStories } -> withIcons renderConfig (demoTable renderConfig Book.tablePixelColumns tablesStories.selecTableState Stories.ForSelectable)
+        , { defaultWithMenu
+            | note = "See [docs](https://package.elm-lang.org/packages/PaackEng/paack-ui/latest/UI-Tables-Stateful) for the exact code of this example."
+          }
+        )
+
+
+portionColumnsTable renderConfig =
+    storyWithModel
+        ( "Portion Columns"
+        , \{ tablesStories } -> withIcons renderConfig (demoTable renderConfig Book.tablePortionColumns tablesStories.selecTableState Stories.ForSelectable)
         , { defaultWithMenu
             | note = "See [docs](https://package.elm-lang.org/packages/PaackEng/paack-ui/latest/UI-Tables-Stateful) for the exact code of this example."
           }

--- a/src/UI/Internal/Tables/View.elm
+++ b/src/UI/Internal/Tables/View.elm
@@ -63,7 +63,7 @@ widthToEl : Common.ColumnWidth -> Element.Length
 widthToEl width =
     case width of
         WidthPortion int ->
-            fillPortion int
+            fillPortion int |> minimum 0
 
         WidthPixels int ->
             px int


### PR DESCRIPTION
#### :thinking: What?
Fixing the issue where the portion columns were overflowing
Adding an example to cover this use case


#### :pushpin: Jira Issue
[WMS-473](https://paacklogistics.atlassian.net/browse/WMS-473)