### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ loginTitle { t } cfg =
 
 This module's repository includes a showcase that itself is not an example of the module's usage but demonstrates the components and their appearance.
 
-A published version of the showcase is available at (paackeng.github.io/paack-ui)[https://paackeng.github.io/paack-ui].
+A published version of the showcase is available at [paackeng.github.io/paack-ui](https://paackeng.github.io/paack-ui).
 
 ## Assets
 


### PR DESCRIPTION
#### :thinking: What?
Fix markdown link.


#### :man_shrugging: Why?
Because the MD was wrong