### PR TITLE
Replace setEllipsis with withOverflow

### DIFF
--- a/src/UI/Internal/Tables/View.elm
+++ b/src/UI/Internal/Tables/View.elm
@@ -12,7 +12,7 @@ import UI.Internal.Utils.Element as InternalElement
 import UI.Palette as Palette exposing (brightnessMiddle, toneGray)
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Tables.Common as Common exposing (..)
-import UI.Text as Text exposing (Text)
+import UI.Text as Text exposing (Text, ellipsizeWithTooltip)
 
 
 cellContentRender : RenderConfig -> Common.Cell msg -> Element msg
@@ -31,7 +31,7 @@ cellContentRender renderConfig cell_ =
 simpleText : RenderConfig -> Text -> Element msg
 simpleText renderConfig text =
     text
-        |> Text.setEllipsis True
+        |> Text.withOverflow ellipsizeWithTooltip
         |> Text.renderElement renderConfig
         |> Element.el
             [ Element.width fill

--- a/src/UI/Internal/Text.elm
+++ b/src/UI/Internal/Text.elm
@@ -6,7 +6,7 @@ import Html exposing (Html)
 import List
 import UI.Internal.Basics exposing (ifThenElse)
 import UI.Internal.Palette as Palette
-import UI.Internal.Utils.Element exposing (ellipsisAttrs, overflowVisible)
+import UI.Internal.Utils.Element exposing (oveflowAttrs, overflowVisible)
 import UI.Palette as Palette exposing (brightnessDarkest, toneGray)
 import UI.RenderConfig exposing (RenderConfig, isMobile)
 import UI.Utils.Element as Element
@@ -22,7 +22,6 @@ type Span
 
 type alias Options =
     { color : TextColor
-    , oneLineEllipsis : Bool
     }
 
 
@@ -33,7 +32,7 @@ type alias SpanProperties =
 
 
 type alias TextOptions =
-    { ellipsis : Bool }
+    { overflow : TextOverflow }
 
 
 type TextSize
@@ -57,6 +56,12 @@ type TextColor
     | ColorInherit
 
 
+type TextOverflow
+    = Ellipsize
+    | EllipsizeWithTooltip
+    | Wrap
+
+
 defaultText : TextSize -> String -> Text
 defaultText size content =
     Text [ Span (SpanProperties content size) spanDefaultOptions ] textDefaultOptions
@@ -65,13 +70,12 @@ defaultText size content =
 spanDefaultOptions : Options
 spanDefaultOptions =
     { color = defaultColor
-    , oneLineEllipsis = False
     }
 
 
 textDefaultOptions : TextOptions
 textDefaultOptions =
-    { ellipsis = False }
+    { overflow = Wrap }
 
 
 defaultColor : TextColor
@@ -92,8 +96,8 @@ fontColor color =
             Nothing
 
 
-attributes : RenderConfig -> TextSize -> Bool -> TextColor -> List (Attribute msg)
-attributes config size ellipsis color =
+attributes : RenderConfig -> TextSize -> TextOverflow -> TextColor -> List (Attribute msg)
+attributes config size overflow color =
     let
         mobile =
             isMobile config
@@ -106,7 +110,7 @@ attributes config size ellipsis color =
                 deskAttributes size
 
         heightAttr attrs =
-            if ellipsis then
+            if shouldEllipsize overflow then
                 overflowVisible :: oneLineHeight mobile size :: attrs
 
             else
@@ -334,13 +338,32 @@ spanMapOptions applier (Span prop opt) =
     Span prop (applier opt)
 
 
-spanRenderEl : RenderConfig -> Span -> Element msg
-spanRenderEl cfg (Span { content, size } { color, oneLineEllipsis }) =
+spanRenderEl : RenderConfig -> TextOptions -> Span -> Element msg
+spanRenderEl cfg { overflow } (Span { content, size } { color }) =
     content
-        |> ifThenElse oneLineEllipsis (ellipsizedText cfg size) Element.text
+        |> renderText cfg overflow size
         |> List.singleton
         |> Element.paragraph
-            (attributes cfg size oneLineEllipsis color)
+            (attributes cfg size overflow color)
+
+
+renderText : RenderConfig -> TextOverflow -> TextSize -> String -> Element msg
+renderText cfg overflow size text =
+    case overflow of
+        Wrap ->
+            Element.text text
+
+        Ellipsize ->
+            ellipsizedText cfg size text
+
+        EllipsizeWithTooltip ->
+            ellipsizedTextWith cfg
+                ellipsizableNode
+                [ ( "white-space", "normal" )
+                , ( "oveflow", "visible" )
+                ]
+                size
+                text
 
 
 getSpans : Text -> List Span
@@ -353,33 +376,49 @@ textMapOptions applier (Text spans combo) =
     Text spans (applier combo)
 
 
-setEllipsis : Bool -> Text -> Text
-setEllipsis val text =
+withOverflow : TextOverflow -> Text -> Text
+withOverflow overflow text =
     text
-        |> mapOptions (\opt -> { opt | oneLineEllipsis = val })
-        |> textMapOptions (\opt -> { opt | ellipsis = val })
+        |> textMapOptions (\opt -> { opt | overflow = overflow })
+
+
+shouldEllipsize : TextOverflow -> Bool
+shouldEllipsize overflow =
+    overflow == Ellipsize || overflow == EllipsizeWithTooltip
 
 
 combinedAttrs : TextOptions -> List (Attribute msg)
-combinedAttrs { ellipsis } =
-    if ellipsis then
+combinedAttrs { overflow } =
+    if shouldEllipsize overflow then
         [ Element.width fill ]
 
     else
         []
 
 
-ellipsizedText : RenderConfig -> TextSize -> String -> Element msg
-ellipsizedText cfg size content =
+ellipsizedTextWith : RenderConfig -> (String -> Html msg) -> List ( String, String ) -> TextSize -> String -> Element msg
+ellipsizedTextWith cfg toHtml attrs size content =
     let
         lineHeightSize =
             lineHeight (isMobile cfg) size
     in
     content
-        |> ellipsizableNode
+        |> toHtml
         |> Element.html
         |> Element.el
-            (ellipsisAttrs lineHeightSize content)
+            (oveflowAttrs lineHeightSize attrs content)
+
+
+ellipsizedText : RenderConfig -> TextSize -> String -> Element msg
+ellipsizedText cfg size content =
+    ellipsizedTextWith cfg
+        Html.text
+        [ ( "text-overflow", "ellipsis" )
+        , ( "white-space", "nowrap" )
+        , ( "oveflow", "hidden" )
+        ]
+        size
+        content
 
 
 ellipsizableNode : String -> Html msg

--- a/src/UI/Internal/Text.elm
+++ b/src/UI/Internal/Text.elm
@@ -6,7 +6,7 @@ import Html exposing (Html)
 import List
 import UI.Internal.Basics exposing (ifThenElse)
 import UI.Internal.Palette as Palette
-import UI.Internal.Utils.Element exposing (oveflowAttrs, overflowVisible)
+import UI.Internal.Utils.Element exposing (overflowAttrs, overflowVisible)
 import UI.Palette as Palette exposing (brightnessDarkest, toneGray)
 import UI.RenderConfig exposing (RenderConfig, isMobile)
 import UI.Utils.Element as Element
@@ -360,7 +360,7 @@ renderText cfg overflow size text =
             ellipsizedTextWith cfg
                 ellipsizableNode
                 [ ( "white-space", "normal" )
-                , ( "oveflow", "visible" )
+                , ( "overflow", "visible" )
                 ]
                 size
                 text
@@ -405,7 +405,7 @@ ellipsizedTextWith cfg toHtml attrs size content =
         |> toHtml
         |> Element.html
         |> Element.el
-            (oveflowAttrs lineHeightSize attrs content)
+            (overflowAttrs lineHeightSize attrs content)
 
 
 ellipsizedText : RenderConfig -> TextSize -> String -> Element msg
@@ -414,7 +414,7 @@ ellipsizedText cfg size content =
         Html.text
         [ ( "text-overflow", "ellipsis" )
         , ( "white-space", "nowrap" )
-        , ( "oveflow", "hidden" )
+        , ( "overflow", "hidden" )
         ]
         size
         content

--- a/src/UI/Internal/Text.elm
+++ b/src/UI/Internal/Text.elm
@@ -357,13 +357,7 @@ renderText cfg overflow size text =
             ellipsizedText cfg size text
 
         EllipsizeWithTooltip ->
-            ellipsizedTextWith cfg
-                ellipsizableNode
-                [ ( "white-space", "normal" )
-                , ( "overflow", "visible" )
-                ]
-                size
-                text
+            ellipsizedTextWithTooltip cfg size text
 
 
 getSpans : Text -> List Span
@@ -415,6 +409,17 @@ ellipsizedText cfg size content =
         [ ( "text-overflow", "ellipsis" )
         , ( "white-space", "nowrap" )
         , ( "overflow", "hidden" )
+        ]
+        size
+        content
+
+
+ellipsizedTextWithTooltip : RenderConfig -> TextSize -> String -> Element msg
+ellipsizedTextWithTooltip cfg size content =
+    ellipsizedTextWith cfg
+        ellipsizableNode
+        [ ( "white-space", "normal" )
+        , ( "overflow", "visible" )
         ]
         size
         content

--- a/src/UI/Internal/Text.elm
+++ b/src/UI/Internal/Text.elm
@@ -378,8 +378,7 @@ textMapOptions applier (Text spans combo) =
 
 withOverflow : TextOverflow -> Text -> Text
 withOverflow overflow text =
-    text
-        |> textMapOptions (\opt -> { opt | overflow = overflow })
+    textMapOptions (\opt -> { opt | overflow = overflow }) text
 
 
 shouldEllipsize : TextOverflow -> Bool

--- a/src/UI/Internal/ToggleableList.elm
+++ b/src/UI/Internal/ToggleableList.elm
@@ -9,7 +9,7 @@ import UI.Internal.Basics exposing (ifThenElse)
 import UI.Palette as Palette exposing (brightnessDarkest, brightnessLight, brightnessLighter, brightnessLightest, brightnessMiddle, toneGray, tonePrimary)
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Size as Size
-import UI.Text as Text
+import UI.Text as Text exposing (ellipsize)
 import UI.Utils.Element exposing (zeroPadding)
 
 
@@ -72,7 +72,7 @@ detailItem renderConfig ( label, content ) =
         [ label
             |> Text.overline
             |> Text.withColor (Palette.color toneGray brightnessLight)
-            |> Text.setEllipsis True
+            |> Text.withOverflow ellipsize
             |> Text.renderElement renderConfig
         , content
         ]
@@ -138,6 +138,6 @@ coverView cfg { title, caption } selected =
                     titleComponent
     in
     captionApplied
-        |> Text.setEllipsis True
+        |> Text.withOverflow ellipsize
         |> Text.renderElement cfg
         |> Element.el [ Element.width fill, Element.clipX ]

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -16,13 +16,10 @@ tuplesToStyles ( k, v ) =
     Element.htmlAttribute <| HtmlAttrs.style k v
 
 
-ellipsisAttrs : Int -> String -> List (Attribute msg)
-ellipsisAttrs lineHeightSize titleContent =
-    [ ( "overflow", "visible" )
-    , ( "display", "block" )
-    , ( "white-space", "normal" )
-    , ( "line-height", String.fromInt lineHeightSize ++ "px" )
-    ]
+oveflowAttrs : Int -> List ( String, String ) -> String -> List (Attribute msg)
+oveflowAttrs lineHeightSize attrs titleContent =
+    attrs
+        |> (::) ( "line-height", String.fromInt lineHeightSize ++ "px" )
         |> List.map tuplesToStyles
         |> (::) Element.clip
         |> (::) (title titleContent)

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -16,8 +16,8 @@ tuplesToStyles ( k, v ) =
     Element.htmlAttribute <| HtmlAttrs.style k v
 
 
-oveflowAttrs : Int -> List ( String, String ) -> String -> List (Attribute msg)
-oveflowAttrs lineHeightSize attrs titleContent =
+overflowAttrs : Int -> List ( String, String ) -> String -> List (Attribute msg)
+overflowAttrs lineHeightSize attrs titleContent =
     attrs
         |> (::) ( "line-height", String.fromInt lineHeightSize ++ "px" )
         |> List.map tuplesToStyles

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -19,7 +19,10 @@ tuplesToStyles ( k, v ) =
 overflowAttrs : Int -> List ( String, String ) -> String -> List (Attribute msg)
 overflowAttrs lineHeightSize attrs titleContent =
     attrs
-        |> (::) ( "line-height", String.fromInt lineHeightSize ++ "px" )
+        |> (++)
+            [ ( "display", "block" )
+            , ( "line-height", String.fromInt lineHeightSize ++ "px" )
+            ]
         |> List.map tuplesToStyles
         |> (::) Element.clip
         |> (::) (title titleContent)

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -19,10 +19,8 @@ tuplesToStyles ( k, v ) =
 overflowAttrs : Int -> List ( String, String ) -> String -> List (Attribute msg)
 overflowAttrs lineHeightSize attrs titleContent =
     attrs
-        |> (++)
-            [ ( "display", "block" )
-            , ( "line-height", String.fromInt lineHeightSize ++ "px" )
-            ]
+        |> (::) ( "display", "block" )
+        |> (::) ( "line-height", String.fromInt lineHeightSize ++ "px" )
         |> List.map tuplesToStyles
         |> (::) Element.clip
         |> (::) (title titleContent)

--- a/src/UI/Text.elm
+++ b/src/UI/Text.elm
@@ -6,9 +6,8 @@ module UI.Text exposing
     , caption, overline
     , multiline, combination
     , withColor
-    , withOverflow
+    , withOverflow, ellipsize, ellipsizeWithTooltip, wrap
     , renderElement
-    , ellipsize, ellipsizeWithTooltip, wrap
     )
 
 {-| `UI.Text` is a component to specify how text to display text. It applies font size, weight, letter-spacing, and color.
@@ -63,7 +62,7 @@ A text can be created and rendered as in the following pipeline:
 
 # Overflow
 
-@docs withOverflow
+@docs withOverflow, ellipsize, ellipsizeWithTooltip, wrap
 
 
 # Rendering

--- a/src/UI/Text.elm
+++ b/src/UI/Text.elm
@@ -206,7 +206,7 @@ wrap =
     Internal.Wrap
 
 
-{-| Determinines how the text overflow is handled.
+{-| Determines how the text overflow is handled.
 
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         |> Text.heading3

--- a/src/UI/Text.elm
+++ b/src/UI/Text.elm
@@ -6,8 +6,8 @@ module UI.Text exposing
     , caption, overline
     , multiline, combination
     , withColor
-    , setEllipsis
     , renderElement
+    , ellipsize, ellipsizeWithTooltip, withOverflow, wrap
     )
 
 {-| `UI.Text` is a component to specify how text to display text. It applies font size, weight, letter-spacing, and color.
@@ -73,7 +73,7 @@ A text can be created and rendered as in the following pipeline:
 
 import Element exposing (Element)
 import List
-import UI.Internal.Text as Internal exposing (TextSize(..), defaultText, mapOptions)
+import UI.Internal.Text as Internal exposing (TextOverflow, TextSize(..), defaultText, mapOptions)
 import UI.Palette as Palette
 import UI.RenderConfig exposing (RenderConfig)
 
@@ -183,6 +183,21 @@ withColor color text =
     mapOptions (\opt -> { opt | color = Internal.ColorPalette color }) text
 
 
+ellipsize : TextOverflow
+ellipsize =
+    Internal.Ellipsize
+
+
+ellipsizeWithTooltip : TextOverflow
+ellipsizeWithTooltip =
+    Internal.EllipsizeWithTooltip
+
+
+wrap : TextOverflow
+wrap =
+    Internal.Wrap
+
+
 {-| If `True`, drop the text instead of wrapping it to a new line, append an ellipsis at the end.
 
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
@@ -192,9 +207,9 @@ withColor color text =
         |> Element.el [ Element.width (px 42) ]
 
 -}
-setEllipsis : Bool -> Text -> Text
-setEllipsis val text =
-    Internal.setEllipsis val text
+withOverflow : TextOverflow -> Text -> Text
+withOverflow overflow text =
+    Internal.withOverflow overflow text
 
 
 {-| End of the builder's life.
@@ -207,10 +222,10 @@ renderElement cfg (Internal.Text spans opt) =
             Element.none
 
         [ theOne ] ->
-            Internal.spanRenderEl cfg theOne
+            Internal.spanRenderEl cfg opt theOne
 
         _ ->
-            List.map (Internal.spanRenderEl cfg) spans
+            List.map (Internal.spanRenderEl cfg opt) spans
                 |> Element.column (Internal.combinedAttrs opt)
 
 

--- a/src/UI/Text.elm
+++ b/src/UI/Text.elm
@@ -6,8 +6,9 @@ module UI.Text exposing
     , caption, overline
     , multiline, combination
     , withColor
+    , withOverflow
     , renderElement
-    , ellipsize, ellipsizeWithTooltip, withOverflow, wrap
+    , ellipsize, ellipsizeWithTooltip, wrap
     )
 
 {-| `UI.Text` is a component to specify how text to display text. It applies font size, weight, letter-spacing, and color.
@@ -20,7 +21,7 @@ A text can be created and rendered as in the following pipeline:
         |> Text.body1
         |> Text.withColor
             (Palette.color tonePrimary brightnessDarkest)
-        |> Text.setEllipsis True
+        |> Text.withOverflow ellipsize
         |> Text.renderElement renderConfig
         |> Element.el [ Element.width (px 200) ]
 
@@ -60,9 +61,9 @@ A text can be created and rendered as in the following pipeline:
 @docs withColor
 
 
-# Ellipsis
+# Overflow
 
-@docs setEllipsis
+@docs withOverflow
 
 
 # Rendering
@@ -183,26 +184,33 @@ withColor color text =
     mapOptions (\opt -> { opt | color = Internal.ColorPalette color }) text
 
 
+{-| Truncates the text and adds the ellipsis.
+-}
 ellipsize : TextOverflow
 ellipsize =
     Internal.Ellipsize
 
 
+{-| Truncates the text, adds the ellipsis and displays a tooltip with the whole content.
+-}
 ellipsizeWithTooltip : TextOverflow
 ellipsizeWithTooltip =
     Internal.EllipsizeWithTooltip
 
 
+{-| Lets the text break lines to prevent overflow.
+Default behavior.
+-}
 wrap : TextOverflow
 wrap =
     Internal.Wrap
 
 
-{-| If `True`, drop the text instead of wrapping it to a new line, append an ellipsis at the end.
+{-| Determinines how the text overflow is handled.
 
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         |> Text.heading3
-        |> Text.setEllipsis True
+        |> Text.withOverflow ellipsize
         |> Text.renderElement renderConfig
         |> Element.el [ Element.width (px 42) ]
 

--- a/src/UI/TextField.elm
+++ b/src/UI/TextField.elm
@@ -700,7 +700,7 @@ textAttrs cfg size =
                 Size.ExtraSmall ->
                     Text.SizeCaption
     in
-    Text.attributes cfg textSize False Text.ColorInherit
+    Text.attributes cfg textSize Text.wrap Text.ColorInherit
 
 
 genericAttr : String -> Bool -> Bool -> TextFieldWidth -> Size -> List (Attribute msg)


### PR DESCRIPTION
#### :thinking: What?
Replace `setEllipsis` function with a new `withOverflow` function


#### :man_shrugging: Why?
Because we need to stop defaulting to the tooltip behavior for every case


#### :pushpin: Jira Issue
[WMS-519](https://paacklogistics.atlassian.net/browse/WMS-519)

