### PR TITLE
WMS-518 | Fix filter dialog overflow and set dimensions for checkboxes and radio buttons

### DIFF
--- a/src/UI/Checkbox.elm
+++ b/src/UI/Checkbox.elm
@@ -183,13 +183,13 @@ pxSize : Size -> Int
 pxSize size =
     case size of
         Size.ExtraSmall ->
-            16
+            10
 
         Size.Small ->
-            20
+            16
 
         Size.Medium ->
-            26
+            20
 
         Size.Large ->
-            32
+            26

--- a/src/UI/Checkbox.elm
+++ b/src/UI/Checkbox.elm
@@ -1,7 +1,6 @@
 module UI.Checkbox exposing
     ( Checkbox, checkbox
     , withLabelVisible
-    , withSize
     , renderElement
     )
 
@@ -43,7 +42,6 @@ import Element.Events as Events
 import UI.Icon as Icon
 import UI.Internal.Palette as Palette
 import UI.Internal.RenderConfig exposing (localeTerms)
-import UI.Internal.Size as Size exposing (Size)
 import UI.Palette as Palette
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Text as Text
@@ -66,7 +64,6 @@ type alias Properties msg =
 
 type alias Options =
     { labelVisible : Bool
-    , size : Size
     }
 
 
@@ -80,7 +77,7 @@ type alias Options =
 checkbox : String -> (Bool -> msg) -> Bool -> Checkbox msg
 checkbox label message state =
     Checkbox { message = message, label = label, state = state }
-        { labelVisible = True, size = Size.default }
+        { labelVisible = True }
 
 
 {-| Show or hide the checkbox's label.
@@ -93,34 +90,15 @@ withLabelVisible bool (Checkbox prop opt) =
     Checkbox prop { opt | labelVisible = bool }
 
 
-{-| With `Checkbox.withSize`, you'll be able to scale the box between the [standard sizes][size].
-
-[size]: UI-Size
-
-The sizes (in height) are: Large - 32px; Medium - 26px; Small - 20px; Extra Small - 16px.
-
-    TextField.withSize Size.large someField
-
-**NOTE**: Checkbox's default size is [`Size.medium`](UI-Size#medium)
-
--}
-withSize : Size -> Checkbox msg -> Checkbox msg
-withSize size (Checkbox prop opt) =
-    Checkbox prop { opt | size = size }
-
-
 {-| End of the builder's life.
 The result of this function is a ready-to-insert Elm UI's Element.
 -}
 renderElement : RenderConfig -> Checkbox msg -> Element msg
-renderElement renderConfig (Checkbox { message, label, state } { labelVisible, size }) =
+renderElement renderConfig (Checkbox { message, label, state } { labelVisible }) =
     let
-        sizeSide =
-            pxSize size
-
         boxAttrs =
-            [ Element.width (px sizeSide)
-            , Element.height (px sizeSide)
+            [ Element.width (px 20)
+            , Element.height (px 20)
             , Border.color Palette.primary.middle
             , Border.width 2
             , Border.rounded 8
@@ -177,19 +155,3 @@ boxCheck renderConfig =
             [ Element.centerY
             , Element.centerX
             ]
-
-
-pxSize : Size -> Int
-pxSize size =
-    case size of
-        Size.ExtraSmall ->
-            10
-
-        Size.Small ->
-            16
-
-        Size.Medium ->
-            20
-
-        Size.Large ->
-            26

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -16,7 +16,7 @@ import UI.Internal.RenderConfig exposing (localeTerms)
 import UI.Internal.Size as Size exposing (Size)
 import UI.Internal.Tables.Filters as Filters
 import UI.Internal.Text as Text
-import UI.Internal.Utils.Element exposing (dialogWidthAttrs, overlay, zIndex)
+import UI.Internal.Utils.Element exposing (overlay, tuplesToStyles, zIndex)
 import UI.Palette as Palette
 import UI.Radio as Radio
 import UI.RenderConfig exposing (RenderConfig)
@@ -297,13 +297,13 @@ dialog renderConfig config filter clearMsg applyMsg content =
     in
     overlay config.discardMsg <|
         Element.column
-            (List.append dialogWidthAttrs
-                [ zIndex 9
-                , Element.alignTop
-                , Palette.mainBackground
-                , Primitives.defaultRoundedBorders
-                ]
-            )
+            [ zIndex 9
+            , Element.alignTop
+            , Palette.mainBackground
+            , Primitives.defaultRoundedBorders
+            , tuplesToStyles ( "min-width", "100%" )
+            , tuplesToStyles ( "width", "min-content" )
+            ]
             [ dialogHeader renderConfig config.discardMsg config.label
             , Element.column
                 [ Element.width fill

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -16,7 +16,7 @@ import UI.Internal.RenderConfig exposing (localeTerms)
 import UI.Internal.Size as Size exposing (Size)
 import UI.Internal.Tables.Filters as Filters
 import UI.Internal.Text as Text
-import UI.Internal.Utils.Element exposing (overlay, zIndex)
+import UI.Internal.Utils.Element exposing (dialogWidthAttrs, overlay, zIndex)
 import UI.Palette as Palette
 import UI.Radio as Radio
 import UI.RenderConfig exposing (RenderConfig)
@@ -297,12 +297,13 @@ dialog renderConfig config filter clearMsg applyMsg content =
     in
     overlay config.discardMsg <|
         Element.column
-            [ Element.width fill
-            , zIndex 9
-            , Element.alignTop
-            , Palette.mainBackground
-            , Primitives.defaultRoundedBorders
-            ]
+            (List.append dialogWidthAttrs
+                [ zIndex 9
+                , Element.alignTop
+                , Palette.mainBackground
+                , Primitives.defaultRoundedBorders
+                ]
+            )
             [ dialogHeader renderConfig config.discardMsg config.label
             , Element.column
                 [ Element.width fill

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -33,6 +33,13 @@ title value =
         |> Element.htmlAttribute
 
 
+dialogWidthAttrs : List (Attribute msg)
+dialogWidthAttrs =
+    [ tuplesToStyles ( "width", "min-content" )
+    , tuplesToStyles ( "min-width", "100%" )
+    ]
+
+
 overlayBackground : msg -> Element msg
 overlayBackground onClickMsg =
     Element.el

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -33,13 +33,6 @@ title value =
         |> Element.htmlAttribute
 
 
-dialogWidthAttrs : List (Attribute msg)
-dialogWidthAttrs =
-    [ tuplesToStyles ( "width", "min-content" )
-    , tuplesToStyles ( "min-width", "100%" )
-    ]
-
-
 overlayBackground : msg -> Element msg
 overlayBackground onClickMsg =
     Element.el

--- a/src/UI/Radio.elm
+++ b/src/UI/Radio.elm
@@ -191,8 +191,8 @@ renderButton : RenderConfig -> msg -> String -> Bool -> Element msg
 renderButton renderConfig message label state =
     let
         radioAttrs =
-            Element.width (px 26)
-                :: Element.height (px 26)
+            Element.width (px 20)
+                :: Element.height (px 20)
                 :: Border.color Palette.primary.middle
                 :: Border.width 2
                 :: Border.rounded 8

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -169,7 +169,6 @@ import UI.Internal.Tables.FiltersView as FiltersView
 import UI.Internal.Tables.View exposing (..)
 import UI.ListView as ListView
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
-import UI.Size as Size
 import UI.Tables.Common as Common exposing (..)
 import UI.Utils.TypeNumbers as T
 
@@ -1155,7 +1154,6 @@ selectionCell renderConfig selection item =
         |> internalIsSelected selection
         |> checkbox "Select row" (SelectionSet item)
         |> Checkbox.withLabelVisible False
-        |> Checkbox.withSize Size.small
         |> Checkbox.renderElement renderConfig
         |> Element.el
             [ Element.centerX, Element.centerY ]


### PR DESCRIPTION
#### :thinking: What?
Makes table filters dialog to fit its contents, also sets the dimensions for radio buttons and checkboxes as per [feedback by Sufyan](https://www.figma.com/file/rqAoj2WwQZYoisP2G6d6nJ?node-id=1:41#37303481). I am making checboxes dimension changes part of this PR because they were contributing to the dialog overflow.


#### :man_shrugging: Why?
Since contents of table filter were overflowing its boundary sometimes, have a look at [this PR](https://github.com/PaackEng/wms-web/pull/114) for context.


#### :pushpin: Jira Issue
[WMS-518](https://paacklogistics.atlassian.net/browse/WMS-518)


### :fire: Extra
Now a filter dialog will be sometimes of lesser width than the column width. I tried setting a minimum width (equal to the column width) on the dialog but couldn't make it work because there is no function exposed by Elm-UI to convert `Element.Length` to pixels. I think having lesser width than the column width shouldn't be an issue as having more than column width is not an issue.