### PR TITLE
 Use Keyed elements in Table

### DIFF
--- a/showcase/src/Tables/Book.elm
+++ b/showcase/src/Tables/Book.elm
@@ -132,14 +132,16 @@ tablePortionColumns =
         |> column "Read" (columnWidthPortion 12)
 
 
-toTableRow : Book -> Tables.Row msg T.Five
-toTableRow { author, title, year, acquired, read } =
-    rowEmpty
+toTableRow : Book -> ( String, Tables.Row msg T.Five )
+toTableRow { author, title, year, acquired, read, isbn } =
+    ( isbn
+    , rowEmpty
         |> rowCellText (Text.body2 title)
         |> rowCellText (Text.body2 author)
         |> rowCellText (Text.caption year)
         |> rowCellText (Text.caption <| DateInput.toDD_MM_YYYY "/" <| DateInput.fromPosix Time.utc acquired)
         |> rowCellText (Text.caption <| DateInput.toDD_MM_YYYY "/" <| DateInput.fromPosix Time.utc read)
+    )
 
 
 toTableDetails : Book -> Stateful.Details msg T.Five

--- a/src/UI/Internal/Tables/View.elm
+++ b/src/UI/Internal/Tables/View.elm
@@ -3,6 +3,7 @@ module UI.Internal.Tables.View exposing (..)
 import Element exposing (Attribute, Element, fill, fillPortion, minimum, px, shrink)
 import Element.Background as Background
 import Element.Border as Border
+import Element.Keyed as Keyed
 import UI.Button as Button
 import UI.Internal.NArray as NArray
 import UI.Internal.Palette as Palette
@@ -56,29 +57,35 @@ widthToEl width =
             px int
 
 
-rowRender : RenderConfig -> ToRow msg item columns -> List Column -> item -> List (Element msg)
+rowRender : RenderConfig -> ToRow msg item columns -> List Column -> item -> ( String, List ( String, Element msg ) )
 rowRender renderConfig toRow columns item =
     toRow item
-        |> NArray.toList
-        |> List.map2 (cellRender renderConfig) columns
+        |> Tuple.mapSecond
+            (NArray.toList
+                >> List.map2 (cellRender renderConfig) columns
+            )
 
 
-rowBox : List (Element msg) -> Element msg
-rowBox cells =
-    Element.row
+rowBox : ( String, List ( String, Element msg ) ) -> ( String, Element msg )
+rowBox ( key, cells ) =
+    ( "#" ++ key
+    , Keyed.row
         [ Element.spacing 8
         , Primitives.defaultRoundedBorders
         , Element.width fill
         , Element.mouseOver [ Background.color Palette.gray.lightest ]
         ]
         cells
+    )
 
 
-cellRender : RenderConfig -> Column -> Common.Cell msg -> Element msg
-cellRender renderConfig (Column _ { width }) cell =
-    cell
+cellRender : RenderConfig -> Column -> Common.Cell msg -> ( String, Element msg )
+cellRender renderConfig (Column label { width }) cell =
+    ( "#" ++ label
+    , cell
         |> cellContentRender renderConfig
         |> cellSpace width
+    )
 
 
 cellSpace : Common.ColumnWidth -> Element msg -> Element msg

--- a/src/UI/Tables/Common.elm
+++ b/src/UI/Tables/Common.elm
@@ -168,7 +168,7 @@ type alias Row msg columns =
 {-| Helper for composing a map function for a single row.
 -}
 type alias ToRow msg item columns =
-    item -> Row msg columns
+    item -> ( String, Row msg columns )
 
 
 {-| An empty set of cells for a row.

--- a/src/UI/Tables/Stateless.elm
+++ b/src/UI/Tables/Stateless.elm
@@ -57,6 +57,7 @@ Where `Book` is:
 -}
 
 import Element exposing (Element, shrink)
+import Element.Keyed as Keyed
 import UI.Internal.NArray as NArray
 import UI.Internal.Tables.Common exposing (..)
 import UI.Internal.Tables.View exposing (..)
@@ -177,7 +178,7 @@ desktopView renderConfig prop opt =
         rows =
             List.map (rowRender renderConfig prop.toRow columns >> rowBox) opt.items
     in
-    Element.column
+    Keyed.column
         [ Element.spacing 2
         , Element.width opt.width
         ]
@@ -187,11 +188,13 @@ desktopView renderConfig prop opt =
 headersRender :
     RenderConfig
     -> List Column
-    -> Element msg
+    -> ( String, Element msg )
 headersRender renderConfig columns =
-    Element.row
+    ( "@headers"
+    , Element.row
         headersAttr
         (List.map (headerRender renderConfig) columns)
+    )
 
 
 


### PR DESCRIPTION
This PR is open for discussions as well!

#### :thinking: What?
Uses `Element.Keyed` in `UI.Table`, enhancing diffing.


#### :man_shrugging: Why?
I've made it as a POC, it ended up being easier then it looked like.


#### :gun:  Counter argument
As we don't have that many rows, it may not bring any benefit.


#### :pushpin: Jira Issue
None, mostly a POC.


#### :no_good: Blocked by
#89


#### :clipboard: Pending
In other PR:
- Do the same to `UI.ListView`
- Do the same to `UI.NavigationContainer`


### :fire: Extra
I watched more animes in 2020 than the rest of my entire life.
