### PR TITLE
WMS-529 | Make ellipsizable-text conform to new api

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "elm-hot": "^1.1.4",
     "elm-test": "^0.19.1-revision2",
     "node-elm-compiler": "^5.0.4",
-    "paack-ui-assets": "^0.0.11",
+    "paack-ui-assets": "^0.0.12",
     "parcel-bundler": "^1.12.4",
     "parcel-plugin-asset-copier": "^1.1.0"
   },

--- a/src/UI/Internal/Text.elm
+++ b/src/UI/Internal/Text.elm
@@ -3,6 +3,7 @@ module UI.Internal.Text exposing (..)
 import Element exposing (Attribute, Element, fill)
 import Element.Font as Font
 import Html exposing (Html)
+import Html.Attributes exposing (attribute)
 import List
 import UI.Internal.Basics exposing (ifThenElse)
 import UI.Internal.Palette as Palette
@@ -428,8 +429,8 @@ ellipsizedTextWithTooltip cfg size content =
 ellipsizableNode : String -> Html msg
 ellipsizableNode content =
     Html.node "ellipsizable-text"
+        [ attribute "text" content ]
         []
-        [ Html.text content ]
 
 
 spanLength : Span -> Int

--- a/yarn.lock
+++ b/yarn.lock
@@ -5410,10 +5410,10 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-paack-ui-assets@^0.0.11:
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/paack-ui-assets/-/paack-ui-assets-0.0.11.tgz#33556f65bdc9cd933fefa362717b9e3305d5eeab"
-  integrity sha512-ko6dNzb1QkRrLDd+tl5Cvbh3MXrCJM/V1+uKKNtOur9UgkMKXLqndzqqDL9cE/4haksR50JJJtWfQGLoDLbJzQ==
+paack-ui-assets@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/paack-ui-assets/-/paack-ui-assets-0.0.12.tgz#6c1fe1dd221dc2caebdaea66a590494ae285d977"
+  integrity sha512-/qMg5RFYpeSGqJiFy2rcPjgNPysZqpQu+hx1KtFjgjOA9qtOc4srAfzEi3ID21aL7ylYsSRVhUtvOLBfFjrOgw==
 
 pako@^0.2.5:
   version "0.2.9"


### PR DESCRIPTION
#### :thinking: What?
Makes `ellipsizable-text` use the new API resulting from [this PR](https://github.com/PaackEng/paack-ui-assets/pull/8).


#### :man_shrugging: Why?
[This PR](https://github.com/PaackEng/paack-ui-assets/pull/8) has some details.


#### :pushpin: Jira Issue
[WMS-529](https://paacklogistics.atlassian.net/browse/WMS-529)


#### :no_good: Blocked by
[#8](https://github.com/PaackEng/paack-ui-assets/pull/8)
