### PR TITLE
WMS-549 create login layout module

### DIFF
--- a/showcase/src/Layouts/Model.elm
+++ b/showcase/src/Layouts/Model.elm
@@ -2,9 +2,9 @@ module Layouts.Model exposing (Model, initModel)
 
 
 type alias Model =
-    {}
+    { email : String, password : String }
 
 
 initModel : Model
 initModel =
-    {}
+    { email = "", password = "" }

--- a/showcase/src/Layouts/Model.elm
+++ b/showcase/src/Layouts/Model.elm
@@ -1,0 +1,10 @@
+module Layouts.Model exposing (Model, initModel)
+
+
+type alias Model =
+    {}
+
+
+initModel : Model
+initModel =
+    {}

--- a/showcase/src/Layouts/Msg.elm
+++ b/showcase/src/Layouts/Msg.elm
@@ -1,0 +1,5 @@
+module Layouts.Msg exposing (Msg(..))
+
+
+type Msg
+    = NoOp

--- a/showcase/src/Layouts/Msg.elm
+++ b/showcase/src/Layouts/Msg.elm
@@ -2,4 +2,6 @@ module Layouts.Msg exposing (Msg(..))
 
 
 type Msg
-    = NoOp
+    = SetEmail String
+    | SetPassword String
+    | NoOp

--- a/showcase/src/Layouts/Stories.elm
+++ b/showcase/src/Layouts/Stories.elm
@@ -1,47 +1,68 @@
 module Layouts.Stories exposing (stories, update)
 
+import Element exposing (Element)
 import Layouts.Model as LayoutsModel
 import Layouts.Msg as LayoutsMsg
+import Model exposing (Model)
 import Msg exposing (Msg)
-import PluginOptions exposing (defaultWithMenu)
+import PluginOptions exposing (defaultWithoutMenu)
 import Return exposing (Return)
 import UI.Badge as Badge exposing (Badge)
+import UI.Button as Button
 import UI.Layout.Auth as Auth
 import UI.RenderConfig exposing (RenderConfig)
 import UI.TextField as TextField
-import UI.Button as Button
 import UIExplorer exposing (storiesOf)
-import Utils exposing (ExplorerStory, ExplorerUI, goToDocsCallToAction, prettifyElmCode, storyList)
-import Element
+import Utils exposing (ExplorerStory, ExplorerUI, goToDocsCallToAction, prettifyElmCode, storyList, storyWithModel)
 
 
 update : LayoutsMsg.Msg -> LayoutsModel.Model -> Return LayoutsMsg.Msg LayoutsModel.Model
 update msg model =
-    ( {}, Cmd.none )
+    case msg of
+        LayoutsMsg.SetEmail e ->
+            ( { model | email = e }, Cmd.none )
+
+        LayoutsMsg.SetPassword p ->
+            ( { model | password = p }, Cmd.none )
+
+        LayoutsMsg.NoOp ->
+            ( model, Cmd.none )
 
 
 stories : RenderConfig -> ExplorerUI
 stories cfg =
-    let
-        msg =
-            Msg.LayoutsStoriesMsg LayoutsMsg.NoOp
-    in
     storiesOf
         "Layouts"
-        [ storyList
-            ( "Auth"
-            , [ Auth.view cfg
-                    { title = "Auth Layout Example Story"
-                    , logo = Element.image [] { src = "logo.png", description = "logo" }
-                    , emailField = TextField.username (always msg) "username" ""
-                    , passwordField = TextField.username (always msg) "username" ""
-                    , submitMsg = msg
-                    , submitButton = Button.fromLabel "Login" |> Button.cmd msg Button.primary
-                    }
-                ]
-            , { defaultWithMenu | code = code }
-            )
+        [ demo cfg
         ]
+
+
+demo : RenderConfig -> ExplorerStory
+demo renderConfig =
+    storyWithModel
+        ( "Auth"
+        , view renderConfig
+        , { defaultWithoutMenu
+            | code = code
+            , note = goToDocsCallToAction "Radio"
+          }
+        )
+
+
+view : RenderConfig -> Model -> Element Msg
+view renderConfig { layoutsStories } =
+    let
+        msg =
+            Msg.LayoutsStoriesMsg
+    in
+    Auth.view renderConfig
+        { title = "Auth Layout Example Story"
+        , logo = Element.image [] { src = "logo.png", description = "logo" }
+        , emailField = TextField.username (msg << LayoutsMsg.SetEmail) "username" layoutsStories.email
+        , passwordField = TextField.username (msg << LayoutsMsg.SetPassword) "password" layoutsStories.password
+        , submitMsg = msg LayoutsMsg.NoOp
+        , submitButton = Button.fromLabel "Login" |> Button.cmd (msg LayoutsMsg.NoOp) Button.primary
+        }
 
 
 code : String

--- a/showcase/src/Layouts/Stories.elm
+++ b/showcase/src/Layouts/Stories.elm
@@ -1,0 +1,43 @@
+module Layouts.Stories exposing (stories, update)
+
+import Layouts.Model as LayoutsModel
+import Layouts.Msg as LayoutsMsg
+import Msg exposing (Msg)
+import PluginOptions exposing (defaultWithMenu)
+import Return exposing (Return)
+import UI.Badge as Badge exposing (Badge)
+import UI.Layout.Login as Login
+import UI.RenderConfig exposing (RenderConfig)
+import UI.TextField as TextField
+import UI.Button as Button
+import UIExplorer exposing (storiesOf)
+import Utils exposing (ExplorerStory, ExplorerUI, goToDocsCallToAction, prettifyElmCode, storyList)
+
+
+update : LayoutsMsg.Msg -> LayoutsModel.Model -> Return LayoutsMsg.Msg LayoutsModel.Model
+update msg model =
+    ( {}, Cmd.none )
+
+
+stories : RenderConfig -> ExplorerUI
+stories cfg =
+    let
+        msg =
+            Msg.LayoutsStoriesMsg LayoutsMsg.NoOp
+    in
+    storiesOf
+        "Layouts"
+        [ storyList
+            ( "Login"
+            , [ Login.view cfg
+                    { title = "Login Layout Example Story"
+                    , logoSrc = "logo.png"
+                    , emailField = TextField.username (always msg) "username" ""
+                    , passwordField = TextField.username (always msg) "username" ""
+                    , submitMsg = msg
+                    , submitButton = Button.fromLabel "Login" |> Button.cmd msg Button.primary
+                    }
+                ]
+            , defaultWithMenu
+            )
+        ]

--- a/showcase/src/Layouts/Stories.elm
+++ b/showcase/src/Layouts/Stories.elm
@@ -7,13 +7,12 @@ import Model exposing (Model)
 import Msg exposing (Msg)
 import PluginOptions exposing (defaultWithoutMenu)
 import Return exposing (Return)
-import UI.Badge as Badge exposing (Badge)
 import UI.Button as Button
 import UI.Layout.Auth as Auth
 import UI.RenderConfig exposing (RenderConfig)
 import UI.TextField as TextField
 import UIExplorer exposing (storiesOf)
-import Utils exposing (ExplorerStory, ExplorerUI, goToDocsCallToAction, prettifyElmCode, storyList, storyWithModel)
+import Utils exposing (ExplorerStory, ExplorerUI, goToDocsCallToAction, prettifyElmCode, storyWithModel)
 
 
 update : LayoutsMsg.Msg -> LayoutsModel.Model -> Return LayoutsMsg.Msg LayoutsModel.Model

--- a/showcase/src/Layouts/Stories.elm
+++ b/showcase/src/Layouts/Stories.elm
@@ -6,12 +6,13 @@ import Msg exposing (Msg)
 import PluginOptions exposing (defaultWithMenu)
 import Return exposing (Return)
 import UI.Badge as Badge exposing (Badge)
-import UI.Layout.Login as Login
+import UI.Layout.Auth as Auth
 import UI.RenderConfig exposing (RenderConfig)
 import UI.TextField as TextField
 import UI.Button as Button
 import UIExplorer exposing (storiesOf)
 import Utils exposing (ExplorerStory, ExplorerUI, goToDocsCallToAction, prettifyElmCode, storyList)
+import Element
 
 
 update : LayoutsMsg.Msg -> LayoutsModel.Model -> Return LayoutsMsg.Msg LayoutsModel.Model
@@ -28,16 +29,30 @@ stories cfg =
     storiesOf
         "Layouts"
         [ storyList
-            ( "Login"
-            , [ Login.view cfg
-                    { title = "Login Layout Example Story"
-                    , logoSrc = "logo.png"
+            ( "Auth"
+            , [ Auth.view cfg
+                    { title = "Auth Layout Example Story"
+                    , logo = Element.image [] { src = "logo.png", description = "logo" }
                     , emailField = TextField.username (always msg) "username" ""
                     , passwordField = TextField.username (always msg) "username" ""
                     , submitMsg = msg
                     , submitButton = Button.fromLabel "Login" |> Button.cmd msg Button.primary
                     }
                 ]
-            , defaultWithMenu
+            , { defaultWithMenu | code = code }
             )
         ]
+
+
+code : String
+code =
+    prettifyElmCode """
+Auth.view cfg
+    { title = "Auth Layout Example Story"
+    , logo = Element.image [] { src = "logo.png", description = "logo" }
+    , emailField = TextField.username (always msg) "username" ""
+    , passwordField = TextField.username (always msg) "username" ""
+    , submitMsg = msg
+    , submitButton = Button.fromLabel "Login" |> Button.cmd msg Button.primary
+    }
+"""

--- a/showcase/src/Main.elm
+++ b/showcase/src/Main.elm
@@ -7,6 +7,7 @@ import Checkboxes.Stories as Checkboxes
 import Html exposing (Html, div, img)
 import Html.Attributes exposing (src, style)
 import Icons
+import Layouts.Stories as Layouts
 import LoadingView as LoadingView
 import Model as Model exposing (Model)
 import Msg exposing (Msg(..))
@@ -18,7 +19,6 @@ import Return as R
 import Sizes
 import Tables.Stories as Tables
 import Tabs.Stories as Tabs
-import Layouts.Stories as Layouts   
 import TextField
 import Texts
 import UI.ListView exposing (ListView)
@@ -172,10 +172,10 @@ updateStories msg ({ customModel } as model) =
             TabsPlugin.update submsg customModel.tabs
                 |> (\t -> ( { customModel | tabs = t }, Cmd.none ))
                 |> finishCustomUpdate model
-       
+
         LayoutsStoriesMsg submsg ->
             Layouts.update submsg customModel.layoutsStories
-                |> R.map (\t -> ( { customModel | layoutsStories = t } ))
+                |> R.map (\t -> { customModel | layoutsStories = t })
                 |> finishCustomUpdate model
 
         NoOp ->

--- a/showcase/src/Main.elm
+++ b/showcase/src/Main.elm
@@ -18,6 +18,7 @@ import Return as R
 import Sizes
 import Tables.Stories as Tables
 import Tabs.Stories as Tabs
+import Layouts.Stories as Layouts   
 import TextField
 import Texts
 import UI.ListView exposing (ListView)
@@ -114,6 +115,7 @@ main =
             , Checkboxes.stories renderConfig
             , Radio.stories renderConfig
             , Tabs.stories renderConfig
+            , Layouts.stories renderConfig
             ]
         |> category
             "Complex components"
@@ -169,6 +171,11 @@ updateStories msg ({ customModel } as model) =
         TabMsg submsg ->
             TabsPlugin.update submsg customModel.tabs
                 |> (\t -> ( { customModel | tabs = t }, Cmd.none ))
+                |> finishCustomUpdate model
+       
+        LayoutsStoriesMsg submsg ->
+            Layouts.update submsg {}
+                |> (\t -> ( customModel, Cmd.none ))
                 |> finishCustomUpdate model
 
         NoOp ->

--- a/showcase/src/Main.elm
+++ b/showcase/src/Main.elm
@@ -174,8 +174,8 @@ updateStories msg ({ customModel } as model) =
                 |> finishCustomUpdate model
        
         LayoutsStoriesMsg submsg ->
-            Layouts.update submsg {}
-                |> (\t -> ( customModel, Cmd.none ))
+            Layouts.update submsg customModel.layoutsStories
+                |> R.map (\t -> ( { customModel | layoutsStories = t } ))
                 |> finishCustomUpdate model
 
         NoOp ->

--- a/showcase/src/Model.elm
+++ b/showcase/src/Model.elm
@@ -8,6 +8,7 @@ import Checkboxes.Model as Checkboxes
 import Paginators.Model as Paginators
 import Radio.Model as Radio
 import Tables.Model as Tables
+import Layouts.Model as Layouts
 import Tabs.Model as Tabs
 import UIExplorer.Plugins.Tabs as TabsPlugin
 
@@ -20,6 +21,7 @@ type alias Model =
     , radioStories : Radio.Model
     , tabsStories : Tabs.Model
     , tabs : TabsPlugin.Model
+    , layoutsStories : Layouts.Model
     }
 
 
@@ -32,4 +34,5 @@ init =
     , radioStories = Radio.initModel
     , tabsStories = Tabs.initModel
     , tabs = TabsPlugin.initialModel
+    , layoutsStories = Layouts.initModel
     }

--- a/showcase/src/Model.elm
+++ b/showcase/src/Model.elm
@@ -5,10 +5,10 @@ module Model exposing
 
 import Buttons.Model as Buttons
 import Checkboxes.Model as Checkboxes
+import Layouts.Model as Layouts
 import Paginators.Model as Paginators
 import Radio.Model as Radio
 import Tables.Model as Tables
-import Layouts.Model as Layouts
 import Tabs.Model as Tabs
 import UIExplorer.Plugins.Tabs as TabsPlugin
 

--- a/showcase/src/Msg.elm
+++ b/showcase/src/Msg.elm
@@ -6,6 +6,7 @@ import Paginators.Msg as Paginators
 import Radio.Msg as Radio
 import Tables.Msg as Tables
 import Tabs.Msg as Tabs
+import Layouts.Msg as Layouts
 import UIExplorer.Plugins.Tabs as TabsPlugin
 
 
@@ -15,6 +16,7 @@ type Msg
     | TablesStoriesMsg Tables.Msg
     | CheckboxesStoriesMsg Checkboxes.Msg
     | RadioStoriesMsg Radio.Msg
+    | LayoutsStoriesMsg Layouts.Msg
     | TabsStoriesMsg Tabs.Msg
     | TabMsg TabsPlugin.Msg
     | NoOp

--- a/showcase/src/Msg.elm
+++ b/showcase/src/Msg.elm
@@ -2,11 +2,11 @@ module Msg exposing (Msg(..))
 
 import Buttons.Msg as Buttons
 import Checkboxes.Msg as Checkboxes
+import Layouts.Msg as Layouts
 import Paginators.Msg as Paginators
 import Radio.Msg as Radio
 import Tables.Msg as Tables
 import Tabs.Msg as Tabs
-import Layouts.Msg as Layouts
 import UIExplorer.Plugins.Tabs as TabsPlugin
 
 

--- a/src/UI/Layout/Auth.elm
+++ b/src/UI/Layout/Auth.elm
@@ -1,8 +1,8 @@
-module UI.Layout.Login exposing (view)
+module UI.Layout.Auth exposing (view)
 
 import Element exposing (Element, fill, maximum, minimum, shrink)
 import UI.Button as Button exposing (Button)
-import UI.Palette as Palette exposing (brightnessMiddle, toneGray, tonePrimary)
+import UI.Palette as Palette exposing (brightnessMiddle, tonePrimary)
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
 import UI.Text as Text
 import UI.TextField as TextField exposing (TextField)
@@ -11,7 +11,7 @@ import UI.TextField as TextField exposing (TextField)
 type alias Config msg =
     { emailField : TextField msg
     , passwordField : TextField msg
-    , logoSrc : String
+    , logo : Element msg
     , title : String
     , submitMsg : msg
     , submitButton : Button msg
@@ -28,7 +28,7 @@ titleSpace cfg =
 
 
 view : RenderConfig -> Config msg -> Element msg
-view renderConfig { title, logoSrc, emailField, passwordField, submitMsg, submitButton } =
+view renderConfig { title, logo, emailField, passwordField, submitMsg, submitButton } =
     Element.column
         [ Element.centerY
         , Element.centerX
@@ -41,10 +41,7 @@ view renderConfig { title, logoSrc, emailField, passwordField, submitMsg, submit
             , Element.spaceEvenly
             , Element.spacingXY 0 0
             ]
-            [ Element.image []
-                { src = logoSrc
-                , description = "logo"
-                }
+            [ logo
             , title
                 |> String.split "\n"
                 |> Text.multiline Text.heading5

--- a/src/UI/Layout/Login.elm
+++ b/src/UI/Layout/Login.elm
@@ -1,0 +1,74 @@
+module UI.Layout.Login exposing (view)
+
+import Element exposing (Element, fill, maximum, minimum, shrink)
+import UI.Button as Button exposing (Button)
+import UI.Palette as Palette exposing (brightnessMiddle, toneGray, tonePrimary)
+import UI.RenderConfig as RenderConfig exposing (RenderConfig)
+import UI.Text as Text
+import UI.TextField as TextField exposing (TextField)
+
+
+type alias Config msg =
+    { emailField : TextField msg
+    , passwordField : TextField msg
+    , logoSrc : String
+    , title : String
+    , submitMsg : msg
+    , submitButton : Button msg
+    }
+
+
+titleSpace : RenderConfig -> Int
+titleSpace cfg =
+    if RenderConfig.isMobile cfg then
+        132
+
+    else
+        152
+
+
+view : RenderConfig -> Config msg -> Element msg
+view renderConfig { title, logoSrc, emailField, passwordField, submitMsg, submitButton } =
+    Element.column
+        [ Element.centerY
+        , Element.centerX
+        , Element.spacingXY 0 24
+        , Element.padding 32
+        , Element.width (fill |> maximum 384)
+        ]
+        [ Element.column
+            [ Element.height (shrink |> minimum (titleSpace renderConfig))
+            , Element.spaceEvenly
+            , Element.spacingXY 0 0
+            ]
+            [ Element.image []
+                { src = logoSrc
+                , description = "logo"
+                }
+            , title
+                |> String.split "\n"
+                |> Text.multiline Text.heading5
+                |> Text.withColor (Palette.color tonePrimary brightnessMiddle)
+                |> Text.renderElement renderConfig
+                |> Element.el
+                    [ Element.paddingXY 0 20
+                    , Element.width fill
+                    ]
+            ]
+        , emailField
+            |> TextField.withPlaceholder "jon@paack.co"
+            |> TextField.setLabelVisible True
+            |> TextField.withWidth TextField.widthFull
+            |> TextField.renderElement renderConfig
+        , passwordField
+            |> TextField.withPlaceholder "********"
+            |> TextField.setLabelVisible True
+            |> TextField.withWidth TextField.widthFull
+            |> TextField.withOnEnterPressed submitMsg
+            |> TextField.renderElement renderConfig
+        , Element.column
+            [ Element.paddingXY 0 152 ]
+            [ submitButton
+                |> Button.renderElement renderConfig
+            ]
+        ]


### PR DESCRIPTION
#### :thinking: What?
Extract the login view from WMS to create a reusable "Auth" layout


#### :man_shrugging: Why?
Because we need a way to have the same look and feel for the BR editor's login screen as the WMS 


#### :pushpin: Jira Issue
[WMS-549](https://paacklogistics.atlassian.net/browse/WMS-549)
