### PR TITLE
WMS-553 | Fix badge warning/danger colors

### DIFF
--- a/src/UI/Badge.elm
+++ b/src/UI/Badge.elm
@@ -268,13 +268,13 @@ colors tone brightness =
             )
 
         ( Dark, ToneWarning ) ->
-            ( Palette.color Palette.toneDanger Palette.brightnessDarkest
-            , Palette.color Palette.toneDanger Palette.brightnessLightest
+            ( Palette.color Palette.toneWarning Palette.brightnessDarkest
+            , Palette.color Palette.toneWarning Palette.brightnessLightest
             )
 
         ( Dark, ToneDanger ) ->
-            ( Palette.color Palette.toneWarning Palette.brightnessDarkest
-            , Palette.color Palette.toneWarning Palette.brightnessLightest
+            ( Palette.color Palette.toneDanger Palette.brightnessDarkest
+            , Palette.color Palette.toneDanger Palette.brightnessLightest
             )
 
         ( Dark, ToneSuccess ) ->


### PR DESCRIPTION
#### :thinking: What?
Switch the dark warning/danger badge colors


#### :man_shrugging: Why?
Because they were wrong, basically


#### :pushpin: Jira Issue
[WMS-553](https://paacklogistics.atlassian.net/browse/WMS-553)

