### PR TITLE
WMS-589 | Make our login page comply to LastPass

### DIFF
--- a/src/UI/TextField.elm
+++ b/src/UI/TextField.elm
@@ -672,6 +672,14 @@ attrs cfg prop opt =
 
                 Nothing ->
                     acu
+
+        usernameAttr acu =
+            case prop.content of
+                ContentUsername ->
+                    Element.usernameTag :: acu
+
+                _ ->
+                    acu
     in
     genericAttr prop.label
         isPlaceholder
@@ -680,6 +688,7 @@ attrs cfg prop opt =
         opt.size
         |> eventAttr
         |> focustAttr
+        |> usernameAttr
         |> (++) (textAttrs cfg opt.size)
 
 

--- a/src/UI/Utils/Element.elm
+++ b/src/UI/Utils/Element.elm
@@ -3,6 +3,7 @@ module UI.Utils.Element exposing
     , desktopMaximum
     , svg, title, maxHeightVH, maxHeightPct, minHeightVH
     , disabled, onEnterPressed, onIndividualClick
+    , usernameTag
     , RectangleSides, zeroPadding
     )
 
@@ -27,6 +28,7 @@ module UI.Utils.Element exposing
 # Input
 
 @docs disabled, onEnterPressed, onIndividualClick
+@docs usernameTag
 
 
 # Padding, borders and size
@@ -218,4 +220,15 @@ onIndividualClick message =
     Decode.succeed message
         |> Decode.map (\msg -> { message = msg, stopPropagation = True, preventDefault = True })
         |> HtmlEvents.custom "click"
+        |> Element.htmlAttribute
+
+
+{-| LastPass (the password manager) expects both username and password inputs to be inside an HTML form. As we can't create forms with elm-ui, to trigger the username's autofill, we need either id or name equals to "username".
+
+This function sets the attribute `name="username"`.
+
+-}
+usernameTag : Attribute msg
+usernameTag =
+    HtmlAttrs.attribute "name" "username"
         |> Element.htmlAttribute


### PR DESCRIPTION
#### :thinking: What?
* Adds `name="username"` to username fields.


#### :man_shrugging: Why?
> Right now, we LastPass is not working properly in our login page, it seems that the autocomplete is not working. It’s nice to have it working, Xavier mentioned that we just need to wrap the textfields with a <form> but I think it will be nice to take a look in the last pass documentation and see the best way to approach this.


#### :pushpin: Jira Issue
[WMS-598](https://paacklogistics.atlassian.net/browse/WMS-589)


#### :no_good: Blocked by
Not blocked, based on master.


#### :clipboard: Pending
Nothing.


### :fire: Extra
After merging, requires bump in WMS.
