### PR TITLE
WMS-587 | Fix inconsistencies between Figma's mobile spaces and current implementation

### DIFF
--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -70,6 +70,17 @@ import Element.Border as Border
 import Element.Font as Font
 import UI.Icon as Icon exposing (Icon)
 import UI.Internal.Basics exposing (lazyMap, pairUncurry, prependMaybe)
+import UI.Internal.Button as Internal
+    exposing
+        ( Button(..)
+        , ButtonAction(..)
+        , ButtonBody(..)
+        , ButtonMode(..)
+        , ButtonStyle(..)
+        , ButtonWidth(..)
+        , EmbossedTone(..)
+        , bodyToElement
+        )
 import UI.Internal.Palette as Palette
 import UI.Internal.Primitives as Primitives
 import UI.Internal.Size as Size exposing (Size)
@@ -83,48 +94,28 @@ import UI.Utils.Element as Element
 
 
 type alias Options =
-    { width : ButtonWidth
-    , size : Size
-    }
-
-
-type alias Properties msg =
-    { body : ButtonBody
-    , mode : ButtonMode msg
-    }
+    Internal.Options
 
 
 {-| The `Button msg` type is used for describing the component for later rendering.
 -}
-type Button msg
-    = Button (Properties msg) Options
-    | Toggle (ToggleProperties msg) Options
+type alias Button msg =
+    Internal.Button msg
 
 
 {-| The `ButtonBody` is required when assembling the most-basic `Button msg` type.
 It indicates the contents inside of the desired button, like its label or icon.
 -}
-type ButtonBody
-    = BodyText String
-    | BodyIcon Icon
+type alias ButtonBody =
+    Internal.ButtonBody
 
 
-type ButtonAction msg
-    = ActionMsg msg
-    | ActionRedirect Link
+type alias ButtonAction msg =
+    Internal.ButtonAction msg
 
 
-type ButtonMode msg
-    = ButtonActive (ButtonAction msg) ButtonStyle
-    | ButtonDisabled
-    | ButtonSuccess
-
-
-type EmbossedTone
-    = TonePrimary
-    | ToneDanger
-    | ToneLight
-    | ToneClear
+type alias EmbossedTone =
+    Internal.EmbossedTone
 
 
 {-| Non-toggle buttons must-be styled. The currently available styles are Hyperlink and Embossed.
@@ -136,23 +127,14 @@ It's available through its sub-themes: Primary, Danger, Light, and Clear.
 These only change background and text color.
 
 -}
-type ButtonStyle
-    = StyleEmbossed EmbossedTone
-    | StyleHyperlink
+type alias ButtonStyle =
+    Internal.ButtonStyle
 
 
 {-| Describes a compatible width.
 -}
-type ButtonWidth
-    = WidthFull
-    | WidthShrink
-
-
-type alias ToggleProperties msg =
-    { current : Bool
-    , toggleMsg : Bool -> msg
-    , hint : String
-    }
+type alias ButtonWidth =
+    Internal.ButtonWidth
 
 
 
@@ -611,23 +593,6 @@ staticView cfg size width body theme =
         |> Element.el attrs
 
 
-bodyToElement : RenderConfig -> Size -> ButtonBody -> Element msg
-bodyToElement cfg size body =
-    case body of
-        BodyText str ->
-            Element.el
-                [ Font.size <| textSize size
-                , Element.centerX
-                , Element.spacing 8
-                ]
-                (Element.text str)
-
-        BodyIcon icon ->
-            icon
-                |> Icon.withSize size
-                |> Icon.renderElement cfg
-
-
 
 -- Attributes
 
@@ -716,22 +681,6 @@ borderWidth size =
 
         Size.ExtraSmall ->
             1
-
-
-textSize : Size -> Int
-textSize size =
-    case size of
-        Size.Large ->
-            20
-
-        Size.Medium ->
-            16
-
-        Size.Small ->
-            12
-
-        Size.ExtraSmall ->
-            10
 
 
 

--- a/src/UI/Internal/Button.elm
+++ b/src/UI/Internal/Button.elm
@@ -1,0 +1,130 @@
+module UI.Internal.Button exposing (..)
+
+import Element exposing (Attribute, Element)
+import Element.Font as Font
+import UI.Icon as Icon exposing (Icon)
+import UI.Internal.Size as Size exposing (Size)
+import UI.Link as Link exposing (Link)
+import UI.RenderConfig exposing (RenderConfig)
+import UI.Utils.ARIA as ARIA
+import UI.Utils.Element as Element
+
+
+type alias Options =
+    { width : ButtonWidth
+    , size : Size
+    }
+
+
+type alias Properties msg =
+    { body : ButtonBody
+    , mode : ButtonMode msg
+    }
+
+
+type Button msg
+    = Button (Properties msg) Options
+    | Toggle (ToggleProperties msg) Options
+
+
+type ButtonBody
+    = BodyText String
+    | BodyIcon Icon
+
+
+type ButtonAction msg
+    = ActionMsg msg
+    | ActionRedirect Link
+
+
+type ButtonMode msg
+    = ButtonActive (ButtonAction msg) ButtonStyle
+    | ButtonDisabled
+    | ButtonSuccess
+
+
+type EmbossedTone
+    = TonePrimary
+    | ToneDanger
+    | ToneLight
+    | ToneClear
+
+
+type ButtonStyle
+    = StyleEmbossed EmbossedTone
+    | StyleHyperlink
+
+
+type ButtonWidth
+    = WidthFull
+    | WidthShrink
+
+
+type alias ToggleProperties msg =
+    { current : Bool
+    , toggleMsg : Bool -> msg
+    , hint : String
+    }
+
+
+bodyToElement : RenderConfig -> Size -> ButtonBody -> Element msg
+bodyToElement cfg size body =
+    case body of
+        BodyText str ->
+            Element.el
+                [ Font.size <| textSize size
+                , Element.centerX
+                , Element.spacing 8
+                ]
+                (Element.text str)
+
+        BodyIcon icon ->
+            icon
+                |> Icon.withSize size
+                |> Icon.renderElement cfg
+
+
+textSize : Size -> Int
+textSize size =
+    case size of
+        Size.Large ->
+            20
+
+        Size.Medium ->
+            16
+
+        Size.Small ->
+            12
+
+        Size.ExtraSmall ->
+            10
+
+
+{-| For when designers do designer stuff
+-}
+renderUnstyled : RenderConfig -> List (Attribute msg) -> Button msg -> Element msg
+renderUnstyled renderConfig attributes button =
+    case button of
+        Button { body, mode } { size } ->
+            bodyToElement renderConfig size body
+                |> (case mode of
+                        ButtonActive action _ ->
+                            case action of
+                                ActionMsg onClickMsg ->
+                                    [ Element.pointer
+                                    , Element.onIndividualClick onClickMsg
+                                    ]
+                                        |> (++) (ARIA.toElementAttributes ARIA.roleButton)
+                                        |> (++) attributes
+                                        |> Element.el
+
+                                ActionRedirect link ->
+                                    Link.wrapElement renderConfig attributes link
+
+                        _ ->
+                            identity
+                   )
+
+        Toggle _ _ ->
+            -- TODO: Do it if you need it someday...
+            Element.none

--- a/src/UI/Internal/Nav/StackHeader.elm
+++ b/src/UI/Internal/Nav/StackHeader.elm
@@ -1,0 +1,97 @@
+module UI.Internal.Nav.StackHeader exposing (LeftButton(..), view)
+
+import Element exposing (Element, fill, minimum, shrink)
+import Element.Border as Border
+import Element.Font as Font
+import UI.Button as Button exposing (Button)
+import UI.Icon as Icon exposing (Icon)
+import UI.Internal.Button as Button
+import UI.Internal.Palette as Palette
+import UI.Internal.RenderConfig exposing (localeTerms)
+import UI.Palette as Palette exposing (brightnessMiddle, toneGray)
+import UI.RenderConfig exposing (RenderConfig)
+import UI.Size as Size
+import UI.Text as Text exposing (ellipsize)
+import UI.Utils.Element as Element exposing (zeroPadding)
+
+
+type LeftButton msg
+    = BackButton msg
+    | MenuButton msg
+
+
+view :
+    RenderConfig
+    -> LeftButton msg
+    -> Maybe (Button msg)
+    -> ( String, Maybe String )
+    -> Element msg
+view renderConfig leftButton rightButton label =
+    Element.row
+        [ Element.width fill
+        , Element.paddingEach { top = 14, bottom = 4, left = 4, right = 4 }
+        , Border.widthEach { zeroPadding | bottom = 1 }
+        , Border.color Palette.gray.lightest
+        ]
+        [ leftButtonView renderConfig leftButton
+        , labelView renderConfig label
+        , rightButtonView renderConfig rightButton
+        ]
+
+
+leftButtonView : RenderConfig -> LeftButton msg -> Element msg
+leftButtonView renderConfig leftButton =
+    case leftButton of
+        BackButton msg ->
+            (localeTerms renderConfig).sidebar.expand
+                |> Icon.sandwichMenu
+                |> iconToButton renderConfig msg
+
+        MenuButton msg ->
+            (localeTerms renderConfig).sidebar.previous
+                |> Icon.previousContent
+                |> iconToButton renderConfig msg
+
+
+labelView : RenderConfig -> ( String, Maybe String ) -> Element msg
+labelView renderConfig ( title, maybeSubtitle ) =
+    (case maybeSubtitle of
+        Just subtitle ->
+            Text.combination
+                [ Text.subtitle2 title
+                , Text.caption subtitle
+                ]
+
+        Nothing ->
+            Text.subtitle2 title
+    )
+        |> Text.withOverflow ellipsize
+        |> Text.renderElement renderConfig
+        |> Element.el [ Element.centerY, Font.center, Element.width fill ]
+
+
+rightButtonView : RenderConfig -> Maybe (Button msg) -> Element msg
+rightButtonView renderConfig maybeRightButton =
+    case maybeRightButton of
+        Just rightButton ->
+            rightButton
+                |> Button.withSize Size.medium
+                |> Button.renderUnstyled renderConfig [ Element.padding 8 ]
+
+        Nothing ->
+            Element.el
+                [ Element.width (shrink |> minimum 32)
+                , Element.height (shrink |> minimum 32)
+                , Element.padding 8
+                ]
+                Element.none
+
+
+iconToButton : RenderConfig -> msg -> Icon -> Element msg
+iconToButton renderConfig msg icon =
+    icon
+        |> Icon.withColor (Palette.color toneGray brightnessMiddle)
+        |> Button.fromIcon
+        |> Button.cmd msg Button.clear
+        |> Button.withSize Size.medium
+        |> Button.renderUnstyled renderConfig [ Element.padding 8 ]

--- a/src/UI/Internal/Nav/StackHeader.elm
+++ b/src/UI/Internal/Nav/StackHeader.elm
@@ -76,7 +76,10 @@ rightButtonView renderConfig maybeRightButton =
         Just rightButton ->
             rightButton
                 |> Button.withSize Size.medium
-                |> Button.renderUnstyled renderConfig [ Element.padding 8 ]
+                |> Button.renderUnstyled renderConfig
+                    [ Element.padding 8
+                    , Font.color Palette.gray.middle
+                    ]
 
         Nothing ->
             Element.el

--- a/src/UI/Internal/NavigationContainer.elm
+++ b/src/UI/Internal/NavigationContainer.elm
@@ -11,7 +11,7 @@ type Content msg
 
 type alias StackChild msg =
     { title : ( String, Maybe String )
-    , buttons : List (Button msg)
+    , rightButton : Maybe (Button msg)
     , goBackMsg : msg
     }
 

--- a/src/UI/Internal/NavigationContainer.elm
+++ b/src/UI/Internal/NavigationContainer.elm
@@ -1,7 +1,8 @@
 module UI.Internal.NavigationContainer exposing (Content(..), StackChild, toShowcaseElement)
 
 import Element exposing (Element)
-import UI.Button exposing (Button)
+import UI.Button exposing (Button, ButtonStyle)
+import UI.Text exposing (Text)
 
 
 type Content msg
@@ -10,8 +11,8 @@ type Content msg
 
 
 type alias StackChild msg =
-    { title : String
-    , buttons : List (Button msg)
+    { title : Text
+    , buttons : List (ButtonStyle -> Button msg)
     , goBackMsg : msg
     }
 

--- a/src/UI/Internal/NavigationContainer.elm
+++ b/src/UI/Internal/NavigationContainer.elm
@@ -1,8 +1,7 @@
 module UI.Internal.NavigationContainer exposing (Content(..), StackChild, toShowcaseElement)
 
 import Element exposing (Element)
-import UI.Button exposing (Button, ButtonStyle)
-import UI.Text exposing (Text)
+import UI.Button exposing (Button)
 
 
 type Content msg
@@ -11,8 +10,8 @@ type Content msg
 
 
 type alias StackChild msg =
-    { title : Text
-    , buttons : List (ButtonStyle -> Button msg)
+    { title : ( String, Maybe String )
+    , buttons : List (Button msg)
     , goBackMsg : msg
     }
 

--- a/src/UI/Internal/SideBar.elm
+++ b/src/UI/Internal/SideBar.elm
@@ -4,7 +4,7 @@ import Element exposing (Attribute, Element, fill, fillPortion, height, padding,
 import Element.Background as Background
 import Element.Events as Events
 import Element.Font as Font
-import UI.Button as Button exposing (Button)
+import UI.Button exposing (Button)
 import UI.Icon as Icon exposing (Icon)
 import UI.Internal.Menu as Menu exposing (Menu)
 import UI.Internal.Nav.StackHeader as StackHeader

--- a/src/UI/Internal/SideBar.elm
+++ b/src/UI/Internal/SideBar.elm
@@ -5,8 +5,9 @@ import Element.Background as Background
 import Element.Border as Border
 import Element.Events as Events
 import Element.Font as Font
-import UI.Button as Button exposing (Button, ButtonStyle)
+import UI.Button as Button exposing (Button)
 import UI.Icon as Icon exposing (Icon)
+import UI.Internal.Button as Button
 import UI.Internal.Menu as Menu exposing (Menu)
 import UI.Internal.Palette as Palette
 import UI.Internal.Primitives as Primitives
@@ -15,7 +16,7 @@ import UI.Link as Link exposing (Link)
 import UI.Palette as Palette exposing (brightnessLight, brightnessMiddle, toneGray, tonePrimary)
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Size as Size
-import UI.Text as Text exposing (Text, ellipsize)
+import UI.Text as Text exposing (ellipsize)
 import UI.Utils.ARIA as ARIA
 import UI.Utils.Element as Element exposing (zeroPadding)
 
@@ -42,8 +43,8 @@ mobileDrawer :
     RenderConfig
     -> Element msg
     -> Menu msg
-    -> Text
-    -> Maybe ( msg, List (ButtonStyle -> Button msg) )
+    -> ( String, Maybe String )
+    -> Maybe ( msg, List (Button msg) )
     -> Element msg
 mobileDrawer cfg page menu title maybeStack =
     let
@@ -93,8 +94,8 @@ mobileDrawer cfg page menu title maybeStack =
 -- Internals
 
 
-viewHead : RenderConfig -> Menu msg -> Text -> Maybe ( msg, List (ButtonStyle -> Button msg) ) -> Element msg
-viewHead cfg (Menu.Menu prop _) title maybeStack =
+viewHead : RenderConfig -> Menu msg -> ( String, Maybe String ) -> Maybe ( msg, List (Button msg) ) -> Element msg
+viewHead cfg (Menu.Menu prop _) ( title, maybeSubtitle ) maybeStack =
     let
         sidebarTerms =
             cfg |> localeTerms >> .sidebar
@@ -120,7 +121,16 @@ viewHead cfg (Menu.Menu prop _) title maybeStack =
             ]
 
         titleView =
-            title
+            (case maybeSubtitle of
+                Just subTitle ->
+                    Text.combination
+                        [ Text.subtitle2 title
+                        , Text.caption subTitle
+                        ]
+
+                Nothing ->
+                    Text.subtitle2 title
+            )
                 |> Text.withOverflow ellipsize
                 |> Text.renderElement cfg
     in
@@ -440,7 +450,8 @@ slimIconColor isSelected =
             |> Palette.withAlpha 0.4
 
 
-renderHeaderButton : RenderConfig -> (ButtonStyle -> Button msg) -> Element msg
+renderHeaderButton : RenderConfig -> Button msg -> Element msg
 renderHeaderButton renderConfig button =
-    button Button.clear
-        |> Button.renderElement renderConfig
+    button
+        |> Button.withSize Size.large
+        |> Button.renderUnstyled renderConfig []

--- a/src/UI/Layout/SplitSelectable.elm
+++ b/src/UI/Layout/SplitSelectable.elm
@@ -3,12 +3,11 @@ module UI.Layout.SplitSelectable exposing (Config, MobileConfig, desktop, mobile
 import Element exposing (Element, fill, fillPortion, minimum)
 import Element.Border as Border
 import Element.Keyed as Keyed
-import UI.Button exposing (Button, ButtonStyle)
+import UI.Button exposing (Button)
 import UI.ListView as ListView exposing (ListView)
 import UI.NavigationContainer as Nav
 import UI.Palette as Palette
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
-import UI.Text exposing (Text)
 import UI.Utils.Element as Element exposing (zeroPadding)
 
 
@@ -22,8 +21,8 @@ type alias Config object msg =
 
 
 type alias MobileConfig msg =
-    { buttons : List (ButtonStyle -> Button msg)
-    , title : Text
+    { buttons : List (Button msg)
+    , title : ( String, Maybe String )
     , unselectMsg : msg
     }
 

--- a/src/UI/Layout/SplitSelectable.elm
+++ b/src/UI/Layout/SplitSelectable.elm
@@ -21,7 +21,7 @@ type alias Config object msg =
 
 
 type alias MobileConfig msg =
-    { buttons : List (Button msg)
+    { rightButton : Maybe (Button msg)
     , title : ( String, Maybe String )
     , unselectMsg : msg
     }
@@ -34,7 +34,7 @@ mobile renderConfig mobileConfig layoutConfig =
             Nav.contentStackChild
                 { title = mobileConfig.title
                 , goBackMsg = mobileConfig.unselectMsg
-                , buttons = mobileConfig.buttons
+                , rightButton = mobileConfig.rightButton
                 }
                 layoutConfig.selectedView
 

--- a/src/UI/Layout/SplitSelectable.elm
+++ b/src/UI/Layout/SplitSelectable.elm
@@ -3,11 +3,12 @@ module UI.Layout.SplitSelectable exposing (Config, MobileConfig, desktop, mobile
 import Element exposing (Element, fill, fillPortion, minimum)
 import Element.Border as Border
 import Element.Keyed as Keyed
-import UI.Button exposing (Button)
+import UI.Button exposing (Button, ButtonStyle)
 import UI.ListView as ListView exposing (ListView)
 import UI.NavigationContainer as Nav
 import UI.Palette as Palette
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
+import UI.Text exposing (Text)
 import UI.Utils.Element as Element exposing (zeroPadding)
 
 
@@ -21,8 +22,8 @@ type alias Config object msg =
 
 
 type alias MobileConfig msg =
-    { buttons : List (Button msg)
-    , title : String
+    { buttons : List (ButtonStyle -> Button msg)
+    , title : Text
     , unselectMsg : msg
     }
 

--- a/src/UI/ListView.elm
+++ b/src/UI/ListView.elm
@@ -418,10 +418,10 @@ actionBarView cfg actionBar =
                 (ARIA.toElementAttributes ARIA.roleButton
                     ++ [ Element.width fill
                        , Element.paddingEach
-                            { bottom = 17
+                            { bottom = 12
                             , left = 20
                             , right = 12
-                            , top = 17
+                            , top = 12
                             }
                        , Background.color Palette.primary.lightest
                        , Font.color Palette.primary.middle

--- a/src/UI/NavigationContainer.elm
+++ b/src/UI/NavigationContainer.elm
@@ -83,7 +83,7 @@ Example of usage:
 
 import Element exposing (Element)
 import Html exposing (Html)
-import UI.Button as Button exposing (Button, ButtonStyle)
+import UI.Button as Button exposing (Button)
 import UI.Icon as Icon exposing (Icon)
 import UI.Internal.Dialog as Dialog
 import UI.Internal.Menu as Menu
@@ -91,7 +91,6 @@ import UI.Internal.NavigationContainer as Internal
 import UI.Internal.SideBar as SideBar
 import UI.Link exposing (Link)
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
-import UI.Text as Text exposing (Text)
 import UI.Utils.Element as Element
 
 
@@ -307,10 +306,7 @@ contentMap applier data =
                 |> Internal.ContentStackChild
                     { title = stack.title
                     , goBackMsg = applier stack.goBackMsg
-                    , buttons =
-                        List.map
-                            (\button style -> Button.map applier (button style))
-                            stack.buttons
+                    , buttons = List.map (Button.map applier) stack.buttons
                     }
 
 
@@ -525,12 +521,14 @@ menu applier { menuExpanded } =
     Menu.default (ToggleMenu >> applier) menuExpanded
 
 
-contentProps : String -> Content msg -> ( Element msg, Maybe ( msg, List (ButtonStyle -> Button msg) ), Text )
+contentProps :
+    String
+    -> Content msg
+    -> ( Element msg, Maybe ( msg, List (Button msg) ), ( String, Maybe String ) )
 contentProps mainTitle content =
     case content of
         Internal.ContentSingle body ->
-            -- TODO: Replace subtitle2 with whatever Sufyian decides
-            ( body, Nothing, Text.subtitle2 mainTitle )
+            ( body, Nothing, ( mainTitle, Nothing ) )
 
         Internal.ContentStackChild { title, goBackMsg, buttons } body ->
             ( body, Just ( goBackMsg, buttons ), title )

--- a/src/UI/NavigationContainer.elm
+++ b/src/UI/NavigationContainer.elm
@@ -83,7 +83,7 @@ Example of usage:
 
 import Element exposing (Element)
 import Html exposing (Html)
-import UI.Button as Button exposing (Button)
+import UI.Button as Button exposing (Button, ButtonStyle)
 import UI.Icon as Icon exposing (Icon)
 import UI.Internal.Dialog as Dialog
 import UI.Internal.Menu as Menu
@@ -91,6 +91,7 @@ import UI.Internal.NavigationContainer as Internal
 import UI.Internal.SideBar as SideBar
 import UI.Link exposing (Link)
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
+import UI.Text as Text exposing (Text)
 import UI.Utils.Element as Element
 
 
@@ -306,7 +307,10 @@ contentMap applier data =
                 |> Internal.ContentStackChild
                     { title = stack.title
                     , goBackMsg = applier stack.goBackMsg
-                    , buttons = List.map (Button.map applier) stack.buttons
+                    , buttons =
+                        List.map
+                            (\button style -> Button.map applier (button style))
+                            stack.buttons
                     }
 
 
@@ -521,11 +525,12 @@ menu applier { menuExpanded } =
     Menu.default (ToggleMenu >> applier) menuExpanded
 
 
-contentProps : String -> Content msg -> ( Element msg, Maybe ( msg, List (Button msg) ), String )
+contentProps : String -> Content msg -> ( Element msg, Maybe ( msg, List (ButtonStyle -> Button msg) ), Text )
 contentProps mainTitle content =
     case content of
         Internal.ContentSingle body ->
-            ( body, Nothing, mainTitle )
+            -- TODO: Replace subtitle2 with whatever Sufyian decides
+            ( body, Nothing, Text.subtitle2 mainTitle )
 
         Internal.ContentStackChild { title, goBackMsg, buttons } body ->
             ( body, Just ( goBackMsg, buttons ), title )

--- a/src/UI/NavigationContainer.elm
+++ b/src/UI/NavigationContainer.elm
@@ -306,7 +306,7 @@ contentMap applier data =
                 |> Internal.ContentStackChild
                     { title = stack.title
                     , goBackMsg = applier stack.goBackMsg
-                    , buttons = List.map (Button.map applier) stack.buttons
+                    , rightButton = Maybe.map (Button.map applier) stack.rightButton
                     }
 
 
@@ -524,14 +524,14 @@ menu applier { menuExpanded } =
 contentProps :
     String
     -> Content msg
-    -> ( Element msg, Maybe ( msg, List (Button msg) ), ( String, Maybe String ) )
+    -> ( Element msg, Maybe ( msg, Maybe (Button msg) ), ( String, Maybe String ) )
 contentProps mainTitle content =
     case content of
         Internal.ContentSingle body ->
             ( body, Nothing, ( mainTitle, Nothing ) )
 
-        Internal.ContentStackChild { title, goBackMsg, buttons } body ->
-            ( body, Just ( goBackMsg, buttons ), title )
+        Internal.ContentStackChild { title, goBackMsg, rightButton } body ->
+            ( body, Just ( goBackMsg, rightButton ), title )
 
 
 dialogMap : (a -> b) -> Dialog a -> Dialog b


### PR DESCRIPTION
#### :thinking: What?
Fix inconsistencies between Figma's mobile spaces and current implementation:
* Defines the button's style in the mobile's header;
* Allow customizing the mobile's stacked header's title;
* Update mobile's header's sandwich size and color;
* Center mobile's stacked header title;
* Force mobile's stacked header elliptization;
* Update SelectList's action bar padding.

#### :man_shrugging: Why?
Cause it differed from Figma.


#### :pushpin: Jira Issue
[WMS-587](https://paacklogistics.atlassian.net/browse/WMS-587)


#### :no_good: Blocked by
**Comments in Figma**


#### :clipboard: Pending
Nothing


### :fire: Extra
This JIRA card was smaller, but those changes are all in the same Figma screen/component.
