### PR TITLE
 WSM-605 | Use row instead of wrapped row for horizontal radio group

### DIFF
--- a/src/UI/Radio.elm
+++ b/src/UI/Radio.elm
@@ -211,7 +211,7 @@ renderElement renderConfig (RadioGroup { label, message } { selected, buttons, w
                     Element.column
 
                 Horizontal ->
-                    Element.wrappedRow
+                    Element.row
     in
     buttons
         |> List.map


### PR DESCRIPTION
#### :thinking: What?
 Use `row` instead of `wrappedRow` for horizontal radio group


#### :man_shrugging: Why?
It wasn't straight forward to use horzontal radio group with `wrappedRow`, it required some tinkering with the width of the radio group and the container.


#### :pushpin: Jira Issue
[WMS-605](https://paacklogistics.atlassian.net/browse/WMS-605)