### PR TITLE
Adopt the same CI conditions as WMS; Stop messing Elm indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,9 @@ trim_trailing_whitespace = true
 max_line_length = 0
 trim_trailing_whitespace = false
 
+[*.elm]
+indent_style = space
+indent_size = 4
+
 [COMMIT_EDITMSG]
 max_line_length = 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,17 @@
 name: CI
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [master]
+    tags:
+      - '*'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   lint:
    runs-on: ubuntu-latest
+   if: github.event.pull_request.draft == false
 
    steps:
      - uses: actions/checkout@v2
@@ -37,6 +44,7 @@ jobs:
 
   validate:
      runs-on: ubuntu-latest
+     if: github.event.pull_request.draft == false
 
      steps:
        - uses: actions/checkout@v2
@@ -53,6 +61,7 @@ jobs:
 
   tests:
      runs-on: ubuntu-latest
+     if: github.event.pull_request.draft == false
 
      steps:
        - uses: actions/checkout@v2


### PR DESCRIPTION
#### :thinking: What?
* Adopt the same CI conditions as WMS:
  * Skip draft PRs,
  * Run actions in PRs only once,
  * Run CI on master when merges and tags;
* Stop messing Elm indentation through `.editorconfig`.


#### :man_shrugging: Why?
Small enhancements.


#### :pushpin: Jira Issue
Not tracked.


#### :no_good: Blocked by
Not blocked.


#### :clipboard: Pending
Nothing.