### PR TITLE
WMS-633 | Center and fix padding to the collpased sidebar button

### DIFF
--- a/src/UI/Internal/SideBar.elm
+++ b/src/UI/Internal/SideBar.elm
@@ -195,7 +195,10 @@ slimHeaderView cfg toggleMsg _ =
         |> Element.el
             (headerButtonAttr toggleMsg
                 ++ [ Element.centerX
-                   , Element.paddingEach { top = 8, left = 8, right = 8, bottom = 88 }
+
+                   -- It has 2 levels of padding, because of the extra padding.
+                   -- As we are trying to do the 8dot grid, the top field was set to 16px
+                   , Element.paddingEach { top = 16, left = 8, right = 8, bottom = 88 }
                    ]
             )
 

--- a/src/UI/Internal/SideBar.elm
+++ b/src/UI/Internal/SideBar.elm
@@ -189,13 +189,15 @@ headerView cfg toggleMsg logo =
 
 slimHeaderView : RenderConfig -> msg -> Maybe (Menu.Logo msg) -> Element msg
 slimHeaderView cfg toggleMsg _ =
-    Element.column [ height (px (72 + 48)) ]
-        [ (cfg |> localeTerms >> .sidebar >> .expand)
-            |> Icon.sandwichMenu
-            |> Icon.withSize Size.small
-            |> Icon.renderElement cfg
-            |> Element.el (headerButtonAttr toggleMsg)
-        ]
+    (cfg |> localeTerms >> .sidebar >> .expand)
+        |> Icon.sandwichMenu
+        |> Icon.renderElement cfg
+        |> Element.el
+            (headerButtonAttr toggleMsg
+                ++ [ Element.centerX
+                   , Element.paddingEach { top = 8, left = 8, right = 8, bottom = 88 }
+                   ]
+            )
 
 
 headerButtonAttr : msg -> List (Attribute msg)


### PR DESCRIPTION
#### :thinking: What?
Center and fix padding to the collapsed sidebar button


#### :man_shrugging: Why?
> The menu logo its not aligned when the menu it's in slim mode


#### :pushpin: Jira Issue
[WMS-633](https://paacklogistics.atlassian.net/browse/WMS-633)


#### :no_good: Blocked by
Not blocked, based on master.


#### :clipboard: Pending
- [ ] Bump in WMS.
