### PR TITLE
WMS-715 | Add v2 of dialog as a POC

### DIFF
--- a/cypress/integration/visual-regression.spec.js
+++ b/cypress/integration/visual-regression.spec.js
@@ -48,6 +48,13 @@ describe('Percy Snapshots', () => {
     })
   })
 
+  describe('Dialog', () => {
+    it('Creates a snapshot of dialog component', () => {
+      cy.visit('/#Basics/Dialog/Dialog')
+      cy.percySnapshot('Dialog')
+    })
+  })
+
   describe('Text fields', () => {
     it('Creates a snapshot for default text field', () => {
       cy.visit('/#Basics/TextField/United')

--- a/elm.json
+++ b/elm.json
@@ -29,7 +29,8 @@
         "UI.Utils.ARIA",
         "UI.Utils.Element",
         "UI.Utils.Focus",
-        "UI.Utils.TypeNumbers"
+        "UI.Utils.TypeNumbers",
+        "UI.V2.Dialog"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/showcase/src/Dialog.elm
+++ b/showcase/src/Dialog.elm
@@ -1,0 +1,63 @@
+module Dialog exposing (stories)
+
+import Element
+import Msg
+import PluginOptions exposing (defaultWithoutMenu)
+import UI.Button as Button exposing (Button)
+import UI.Icon as Icon
+import UI.Internal.Palette exposing (overlayBackground)
+import UI.RenderConfig exposing (RenderConfig)
+import UI.Text as Text
+import UI.V2.Dialog as Dialog
+import UIExplorer exposing (storiesOf)
+import Utils exposing (ExplorerStory, ExplorerUI, iconsSvgSprite, prettifyElmCode, story)
+
+
+stories : RenderConfig -> ExplorerUI
+stories cfg =
+    storiesOf
+        "Dialog"
+        [ dialog cfg
+        ]
+
+
+dialog : RenderConfig -> ExplorerStory
+dialog cfg =
+    story
+        ( "Dialog"
+        , Element.column
+            [ Element.centerX
+            , Element.centerY
+            , Element.padding 32
+            , overlayBackground
+            ]
+            [ iconsSvgSprite
+            , Dialog.Dialog
+                { title = "Dialog Header"
+                , icon = Icon.warning "Warning dialog"
+                }
+                { buttons = buttons
+                , body = "I am body of the dialog" |> Text.body2 |> Text.renderElement cfg
+                }
+                |> Dialog.renderElement cfg
+            ]
+        , { defaultWithoutMenu | code = code }
+        )
+
+
+buttons : List (Button Msg.Msg)
+buttons =
+    [ Button.fromLabel "Ok" |> Button.cmd Msg.NoOp Button.primary
+    , Button.fromLabel "Ok" |> Button.cmd Msg.NoOp Button.primary
+    , Button.fromLabel "Ok" |> Button.cmd Msg.NoOp Button.primary
+    ]
+
+
+code : String
+code =
+    prettifyElmCode """
+dialogV2 "Dialog title" Icon.warning
+    |> Dialog.withBody ("Dialog body text" |> Text.body2 |> Text.renderElement cfg)
+    |> Dialog.withButtons
+        (Button.fromLabel "Ok" |> Button.cmd NoOp Button.primary)
+"""

--- a/showcase/src/Dialog.elm
+++ b/showcase/src/Dialog.elm
@@ -6,10 +6,10 @@ import PluginOptions exposing (defaultWithoutMenu)
 import UI.Button as Button exposing (Button)
 import UI.Icon as Icon
 import UI.Internal.Colors exposing (overlayBackground)
+import UI.Internal.DialogV2 exposing (dialogViewV2)
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Text as Text
 import UI.V2.Dialog as Dialog
-import UI.Internal.DialogV2 exposing(dialogViewV2)
 import UIExplorer exposing (storiesOf)
 import Utils exposing (ExplorerStory, ExplorerUI, iconsSvgSprite, prettifyElmCode, story)
 

--- a/showcase/src/Dialog.elm
+++ b/showcase/src/Dialog.elm
@@ -9,6 +9,7 @@ import UI.Internal.Colors exposing (overlayBackground)
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Text as Text
 import UI.V2.Dialog as Dialog
+import UI.Internal.DialogV2 exposing(dialogViewV2)
 import UIExplorer exposing (storiesOf)
 import Utils exposing (ExplorerStory, ExplorerUI, iconsSvgSprite, prettifyElmCode, story)
 
@@ -28,7 +29,8 @@ dialog cfg =
         , Element.column
             [ Element.centerX
             , Element.centerY
-            , Element.padding 100
+            , Element.padding 20
+            , Element.height <| Element.px 500
             , overlayBackground
             ]
             [ iconsSvgSprite
@@ -38,7 +40,7 @@ dialog cfg =
                 |> Dialog.withBody
                     ("Dialog body text" |> Text.body2 |> Text.renderElement cfg)
                 |> Dialog.withButtons buttons
-                |> Dialog.renderElement cfg
+                |> dialogViewV2 cfg
             ]
         , { defaultWithoutMenu | code = code }
         )

--- a/showcase/src/Dialog.elm
+++ b/showcase/src/Dialog.elm
@@ -28,17 +28,16 @@ dialog cfg =
         , Element.column
             [ Element.centerX
             , Element.centerY
-            , Element.padding 32
+            , Element.padding 100
             , overlayBackground
             ]
             [ iconsSvgSprite
-            , Dialog.Dialog
-                { title = "Dialog Header"
-                , icon = Icon.warning "Warning dialog"
-                }
-                { buttons = buttons
-                , body = "I am body of the dialog" |> Text.body2 |> Text.renderElement cfg
-                }
+            , Dialog.dialog "Dialog title"
+                (Icon.warning "Warning dialog")
+                Msg.NoOp
+                |> Dialog.withBody
+                    ("Dialog body text" |> Text.body2 |> Text.renderElement cfg)
+                |> Dialog.withButtons buttons
                 |> Dialog.renderElement cfg
             ]
         , { defaultWithoutMenu | code = code }
@@ -48,16 +47,16 @@ dialog cfg =
 buttons : List (Button Msg.Msg)
 buttons =
     [ Button.fromLabel "Ok" |> Button.cmd Msg.NoOp Button.primary
-    , Button.fromLabel "Ok" |> Button.cmd Msg.NoOp Button.primary
-    , Button.fromLabel "Ok" |> Button.cmd Msg.NoOp Button.primary
+    , Button.fromLabel "Cancel" |> Button.cmd Msg.NoOp Button.danger
     ]
 
 
 code : String
 code =
     prettifyElmCode """
-dialogV2 "Dialog title" Icon.warning
+dialog "Dialog title" Icon.warning closeMsg
     |> Dialog.withBody ("Dialog body text" |> Text.body2 |> Text.renderElement cfg)
     |> Dialog.withButtons
-        (Button.fromLabel "Ok" |> Button.cmd NoOp Button.primary)
+        [(Button.fromLabel "Ok" |> Button.cmd NoOp Button.primary)]
+    |> Dialog.renderElement renderConfig
 """

--- a/showcase/src/Dialog.elm
+++ b/showcase/src/Dialog.elm
@@ -5,7 +5,7 @@ import Msg
 import PluginOptions exposing (defaultWithoutMenu)
 import UI.Button as Button exposing (Button)
 import UI.Icon as Icon
-import UI.Internal.Palette exposing (overlayBackground)
+import UI.Internal.Colors exposing (overlayBackground)
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Text as Text
 import UI.V2.Dialog as Dialog

--- a/showcase/src/Main.elm
+++ b/showcase/src/Main.elm
@@ -2,9 +2,9 @@ module Main exposing (CompileNav, CompilerListView, main)
 
 import Alerts
 import Badges
-import Dialog
 import Buttons.Stories as Buttons
 import Checkboxes.Stories as Checkboxes
+import Dialog
 import Html exposing (Html, div, img)
 import Html.Attributes exposing (src, style)
 import Icons

--- a/showcase/src/Main.elm
+++ b/showcase/src/Main.elm
@@ -2,6 +2,7 @@ module Main exposing (CompileNav, CompilerListView, main)
 
 import Alerts
 import Badges
+import Dialog
 import Buttons.Stories as Buttons
 import Checkboxes.Stories as Checkboxes
 import Html exposing (Html, div, img)
@@ -110,6 +111,7 @@ main =
             , Buttons.stories renderConfig
             , Alerts.stories renderConfig
             , Badges.stories renderConfig
+            , Dialog.stories renderConfig
             , TextField.stories renderConfig
             , LoadingView.stories
             , Checkboxes.stories renderConfig

--- a/src/UI/Internal/DialogV2.elm
+++ b/src/UI/Internal/DialogV2.elm
@@ -5,7 +5,7 @@ import Element.Border as Border
 import Element.Events as Events
 import UI.Button as Button exposing (Button)
 import UI.Icon as Icon exposing (Icon)
-import UI.Internal.Colors exposing (mainBackground)
+import UI.Internal.Colors exposing (mainBackground, overlayBackground)
 import UI.Internal.RenderConfig exposing (RenderConfig, localeTerms)
 import UI.Palette as Palette
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
@@ -17,12 +17,17 @@ import UI.V2.Dialog as Dialog exposing (Dialog)
 
 
 dialogViewV2 : RenderConfig -> Dialog msg -> Element msg
-dialogViewV2 cfg dlg =
+dialogViewV2 cfg ((Dialog.Dialog { close } { closeOnOverlayClick }) as dlg) =
     if RenderConfig.isMobile cfg then
         mobileView cfg dlg
 
     else
         desktopDialogView cfg dlg
+            |> Element.el
+                [ Element.width fill
+                , Element.height fill
+                , Element.behindContent (blackBlock close closeOnOverlayClick)
+                ]
 
 
 desktopDialogView : RenderConfig -> Dialog msg -> Element msg
@@ -159,3 +164,21 @@ titleText cfg title =
 headerColor : Palette.Color
 headerColor =
     Palette.color Palette.toneGray Palette.brightnessMiddle
+
+
+{-| Making overlay part of the dialog since it is almost always used with it and
+almost all of the major UI frameworks follow this practice.
+-}
+blackBlock : msg -> Bool -> Element msg
+blackBlock close shouldCloseOnClick =
+    Element.el
+        [ Element.width fill
+        , Element.height fill
+        , overlayBackground
+        , if shouldCloseOnClick then
+            Events.onClick close
+
+          else
+            Element.width fill
+        ]
+        Element.none

--- a/src/UI/Internal/DialogV2.elm
+++ b/src/UI/Internal/DialogV2.elm
@@ -1,0 +1,161 @@
+module UI.Internal.DialogV2 exposing (dialogViewV2)
+
+import Element exposing (Element, fill, shrink)
+import Element.Border as Border
+import Element.Events as Events
+import UI.Button as Button exposing (Button)
+import UI.Icon as Icon exposing (Icon)
+import UI.Internal.Colors exposing (mainBackground)
+import UI.Internal.RenderConfig exposing (RenderConfig, localeTerms)
+import UI.Palette as Palette
+import UI.RenderConfig as RenderConfig exposing (RenderConfig)
+import UI.Size as Size
+import UI.Text as Text
+import UI.Utils.ARIA as ARIA exposing (roleButton)
+import UI.Utils.Element as Element
+import UI.V2.Dialog as Dialog exposing (Dialog)
+
+
+dialogViewV2 : RenderConfig -> Dialog msg -> Element msg
+dialogViewV2 cfg dlg =
+    if RenderConfig.isMobile cfg then
+        mobileView cfg dlg
+
+    else
+        desktopDialogView cfg dlg
+
+
+desktopDialogView : RenderConfig -> Dialog msg -> Element msg
+desktopDialogView cfg (Dialog.Dialog { title, icon } { body, buttons }) =
+    Element.column
+        [ Element.width shrink
+        , Element.centerY
+        , Element.centerX
+        , mainBackground
+        , Element.paddingEach
+            { top = 0
+            , right = 32
+            , bottom = 32
+            , left = 32
+            }
+        , Border.roundEach
+            { topLeft = 0
+            , topRight = 0
+            , bottomLeft = 6
+            , bottomRight = 6
+            }
+        , Element.above
+            (desktopHeaderRow cfg title icon)
+        ]
+        [ body
+        , buttonsRow cfg buttons
+        ]
+
+
+buttonsRow : RenderConfig -> List (Button msg) -> Element msg
+buttonsRow cfg buttons =
+    Element.row
+        [ Element.spacing 16
+        , Element.paddingEach { top = 24, left = 0, right = 0, bottom = 0 }
+        ]
+    <|
+        List.map
+            (Button.renderElement cfg)
+            buttons
+
+
+desktopHeaderRow : RenderConfig -> String -> Icon -> Element msg
+desktopHeaderRow cfg title icon =
+    Element.row
+        [ Element.spacing 12
+        , Element.width fill
+        , Element.paddingEach { top = 32, bottom = 8, right = 32, left = 32 }
+        , mainBackground
+        , Border.roundEach
+            { topLeft = 6
+            , topRight = 6
+            , bottomLeft = 0
+            , bottomRight = 0
+            }
+        ]
+        [ icon
+            |> Icon.withColor headerColor
+            |> Icon.renderElement cfg
+        , titleText cfg title |> Element.el [ Element.width fill ]
+        ]
+
+
+mobileView : RenderConfig -> Dialog msg -> Element msg
+mobileView cfg (Dialog.Dialog { title, close } { body, buttons }) =
+    Element.column
+        [ Element.width fill
+        , Element.height fill
+        , Element.alignTop
+        , Element.spacing 8
+        , mainBackground
+        ]
+        [ mobileHeaderRow cfg close title
+        , body
+            |> Element.el
+                [ Element.width fill
+                , Element.paddingEach
+                    { top = 0, left = 20, right = 20, bottom = 0 }
+                ]
+        , buttonsRow cfg buttons
+            |> Element.el
+                [ Element.paddingEach
+                    { left = 20
+                    , right = 20
+                    , top = 0
+                    , bottom = 20
+                    }
+                ]
+        ]
+
+
+mobileHeaderRow : RenderConfig -> msg -> String -> Element msg
+mobileHeaderRow cfg close title =
+    Element.row
+        [ Element.width fill
+        , Element.padding 0
+        ]
+        [ titleText cfg
+            title
+            |> Element.el
+                [ Element.paddingEach
+                    { top = 40, left = 20, right = 0, bottom = 0 }
+                , Element.width fill
+                ]
+        , closeButton cfg close
+        ]
+
+
+closeButton : RenderConfig -> msg -> Element msg
+closeButton cfg close =
+    (cfg |> localeTerms >> .dialog >> .close)
+        |> Icon.close
+        |> Icon.withSize Size.small
+        |> Icon.withColor
+            (Palette.color Palette.toneGray Palette.brightnessLight)
+        |> Icon.renderElement cfg
+        |> Element.el
+            (ARIA.toElementAttributes ARIA.roleButton
+                ++ [ Events.onClick close
+                   , Element.pointer
+                   , Element.padding 12
+                   , Element.height shrink
+                   , Element.alignTop
+                   ]
+            )
+
+
+titleText : RenderConfig -> String -> Element msg
+titleText cfg title =
+    Text.heading5 title
+        |> Text.withColor headerColor
+        |> Text.renderElement cfg
+
+
+headerColor : Palette.Color
+headerColor =
+    Palette.color Palette.toneGray Palette.brightnessMiddle

--- a/src/UI/NavigationContainer.elm
+++ b/src/UI/NavigationContainer.elm
@@ -574,7 +574,7 @@ dialogMap applier dlg =
             Dialog1 <| Dialog1.dialogMap applier dialogState
 
         Dialog2 dialogState ->
-            Dialog2 <| Dialog2.dialogMap applier dialogState
+            Dialog2 <| Dialog2.map applier dialogState
 
 
 blackBlock : msg -> Element msg

--- a/src/UI/NavigationContainer.elm
+++ b/src/UI/NavigationContainer.elm
@@ -514,14 +514,9 @@ toBrowserDocument cfg page (Navigator model) =
                 Just (Dialog1 dialogState) ->
                     Dialog1.view cfg dialogState
 
-                Just (Dialog2 ((Dialog2.Dialog { close } _) as dialogState)) ->
+                Just (Dialog2 ((Dialog2.Dialog { close } { closeOnOverlayClick }) as dialogState)) ->
                     dialogState
                         |> dialogViewV2 cfg
-                        |> Element.el
-                            [ Element.width fill
-                            , Element.height fill
-                            , Element.behindContent (blackBlock close)
-                            ]
 
                 Nothing ->
                     Element.none
@@ -576,14 +571,3 @@ dialogMap applier dlg =
 
         Dialog2 dialogState ->
             Dialog2 <| Dialog2.map applier dialogState
-
-
-blackBlock : msg -> Element msg
-blackBlock close =
-    Element.el
-        [ Element.width fill
-        , Element.height fill
-        , Colors.overlayBackground
-        , Events.onClick close
-        ]
-        Element.none

--- a/src/UI/NavigationContainer.elm
+++ b/src/UI/NavigationContainer.elm
@@ -4,9 +4,8 @@ module UI.NavigationContainer exposing
     , Container, containerMap
     , Content, contentSingle, StackChild, contentStackChild
     , withMenuLogo, withMenuActions, MenuAction, menuAction, withMenuPages, MenuPage, menuPage
-    , Dialog, dialog
+    , Dialog, dialog, dialogV2
     , toBrowserDocument
-    , dialogV2
     )
 
 {-| The `UI.NavigationContainer` (abbreviated as `Nav`) is a page presenter.
@@ -73,7 +72,7 @@ Example of usage:
 
 # Dialog
 
-@docs Dialog, dialog
+@docs Dialog, dialog, dialogV2
 
 
 # Rendering

--- a/src/UI/NavigationContainer.elm
+++ b/src/UI/NavigationContainer.elm
@@ -435,7 +435,7 @@ Clicking on the black layer also activates the closing message.
         Msg.NewCardDiscard
         (cardNewView model)
 
-Note: This is deprecated, use 'Nav.dialogV2' instead
+**Note**: This is deprecated, use 'Nav.dialogV2' instead
 
 -}
 dialog : String -> msg -> Element msg -> Dialog msg

--- a/src/UI/NavigationContainer.elm
+++ b/src/UI/NavigationContainer.elm
@@ -87,6 +87,7 @@ import Html exposing (Html)
 import UI.Icon as Icon exposing (Icon)
 import UI.Internal.Colors as Colors
 import UI.Internal.Dialog as Dialog1
+import UI.Internal.DialogV2 exposing (dialogViewV2)
 import UI.Internal.Menu as Menu
 import UI.Internal.NavigationContainer as Internal
 import UI.Internal.SideBar as SideBar
@@ -515,7 +516,7 @@ toBrowserDocument cfg page (Navigator model) =
 
                 Just (Dialog2 ((Dialog2.Dialog { close } _) as dialogState)) ->
                     dialogState
-                        |> Dialog2.renderElement cfg
+                        |> dialogViewV2 cfg
                         |> Element.el
                             [ Element.width fill
                             , Element.height fill

--- a/src/UI/V2/Dialog.elm
+++ b/src/UI/V2/Dialog.elm
@@ -2,7 +2,7 @@ module UI.V2.Dialog exposing
     ( Dialog(..), dialog
     , withBody, withButtons
     , renderElement
-    , dialogMap
+    , map
     )
 
 {-| The `UI.V2.Dialog` is a component for displaying dialogs and modals.
@@ -33,7 +33,7 @@ following pipeline:
 
 # Component handling
 
-@docs dialogMap
+@docs map
 
 -}
 
@@ -86,8 +86,8 @@ dialog title icon closeMsg =
 
 {-| Transforms the message produced by the component.
 -}
-dialogMap : (a -> b) -> Dialog a -> Dialog b
-dialogMap applier (Dialog { title, icon, close } { body, buttons }) =
+map : (a -> b) -> Dialog a -> Dialog b
+map applier (Dialog { title, icon, close } { body, buttons }) =
     Dialog
         { title = title
         , icon = icon

--- a/src/UI/V2/Dialog.elm
+++ b/src/UI/V2/Dialog.elm
@@ -1,7 +1,6 @@
 module UI.V2.Dialog exposing
     ( Dialog(..), dialog
     , withBody, withButtons
-    , renderElement
     , map
     )
 
@@ -24,11 +23,6 @@ following pipeline:
 # Content
 
 @docs withBody, withButtons
-
-
-# Rendering
-
-@docs renderElement
 
 
 # Component handling
@@ -121,159 +115,3 @@ dialog.
 withButtons : List (Button msg) -> Dialog msg -> Dialog msg
 withButtons buttons (Dialog props options) =
     Dialog props { options | buttons = buttons }
-
-
-
--- Rendering
-
-
-{-| End of the builder's life.
-The result of this function is a ready-to-insert Elm UI's Element.
--}
-renderElement : RenderConfig -> Dialog msg -> Element msg
-renderElement cfg dlg =
-    if RenderConfig.isMobile cfg then
-        mobileView cfg dlg
-
-    else
-        desktopDialogView cfg dlg
-
-
-
--- Internal
-
-
-desktopDialogView : RenderConfig -> Dialog msg -> Element msg
-desktopDialogView cfg (Dialog { title, icon } { body, buttons }) =
-    Element.column
-        [ Element.width shrink
-        , Element.centerY
-        , Element.centerX
-        , mainBackground
-        , Element.paddingEach
-            { top = 0
-            , right = 32
-            , bottom = 32
-            , left = 32
-            }
-        , Border.roundEach
-            { topLeft = 0
-            , topRight = 0
-            , bottomLeft = 6
-            , bottomRight = 6
-            }
-        , Element.above
-            (desktopHeaderRow cfg title icon)
-        ]
-        [ body
-        , buttonsRow cfg buttons
-        ]
-
-
-buttonsRow : RenderConfig -> List (Button msg) -> Element msg
-buttonsRow cfg buttons =
-    Element.row
-        [ Element.spacing 16
-        , Element.paddingEach { top = 24, left = 0, right = 0, bottom = 0 }
-        ]
-    <|
-        List.map
-            (Button.renderElement cfg)
-            buttons
-
-
-desktopHeaderRow : RenderConfig -> String -> Icon -> Element msg
-desktopHeaderRow cfg title icon =
-    Element.row
-        [ Element.spacing 12
-        , Element.width fill
-        , Element.paddingEach { top = 32, bottom = 8, right = 32, left = 32 }
-        , mainBackground
-        , Border.roundEach
-            { topLeft = 6
-            , topRight = 6
-            , bottomLeft = 0
-            , bottomRight = 0
-            }
-        ]
-        [ icon
-            |> Icon.withColor headerColor
-            |> Icon.renderElement cfg
-        , titleText cfg title |> Element.el [ Element.width fill ]
-        ]
-
-
-mobileView : RenderConfig -> Dialog msg -> Element msg
-mobileView cfg (Dialog { title, close } { body, buttons }) =
-    Element.column
-        [ Element.width fill
-        , Element.height fill
-        , Element.alignTop
-        , Element.spacing 8
-        , mainBackground
-        ]
-        [ mobileHeaderRow cfg close title
-        , body
-            |> Element.el
-                [ Element.width fill
-                , Element.paddingEach
-                    { top = 0, left = 20, right = 20, bottom = 0 }
-                ]
-        , buttonsRow cfg buttons
-            |> Element.el
-                [ Element.paddingEach
-                    { left = 20
-                    , right = 20
-                    , top = 0
-                    , bottom = 20
-                    }
-                ]
-        ]
-
-
-mobileHeaderRow : RenderConfig -> msg -> String -> Element msg
-mobileHeaderRow cfg close title =
-    Element.row
-        [ Element.width fill
-        , Element.padding 0
-        ]
-        [ titleText cfg
-            title
-            |> Element.el
-                [ Element.paddingEach
-                    { top = 40, left = 20, right = 0, bottom = 0 }
-                , Element.width fill
-                ]
-        , closeButton cfg close
-        ]
-
-
-closeButton : RenderConfig -> msg -> Element msg
-closeButton cfg close =
-    (cfg |> localeTerms >> .dialog >> .close)
-        |> Icon.close
-        |> Icon.withSize Size.small
-        |> Icon.withColor
-            (Palette.color Palette.toneGray Palette.brightnessLight)
-        |> Icon.renderElement cfg
-        |> Element.el
-            (ARIA.toElementAttributes ARIA.roleButton
-                ++ [ Events.onClick close
-                   , Element.pointer
-                   , Element.padding 12
-                   , Element.height shrink
-                   , Element.alignTop
-                   ]
-            )
-
-
-titleText : RenderConfig -> String -> Element msg
-titleText cfg title =
-    Text.heading5 title
-        |> Text.withColor headerColor
-        |> Text.renderElement cfg
-
-
-headerColor : Palette.Color
-headerColor =
-    Palette.color Palette.toneGray Palette.brightnessMiddle

--- a/src/UI/V2/Dialog.elm
+++ b/src/UI/V2/Dialog.elm
@@ -1,0 +1,119 @@
+module UI.V2.Dialog exposing
+    ( Dialog(..)
+    , dialogMap
+    , renderElement
+    , withBody
+    , withButtons
+    )
+
+import Element exposing (Element, fill, shrink)
+import Element.Border as Border
+import UI.Button as Button exposing (Button)
+import UI.Icon as Icon exposing (Icon)
+import UI.Internal.Palette as PaletteInternal
+import UI.Palette as Palette
+import UI.RenderConfig exposing (RenderConfig)
+import UI.Text as Text
+import UI.Utils.Element as Element
+
+
+type Dialog msg
+    = Dialog Properties (Options msg)
+
+
+type alias Properties =
+    { title : String
+    , icon : Icon
+    }
+
+
+type alias Options msg =
+    { body : Element msg
+    , buttons : List (Button msg)
+    }
+
+
+dialogMap : (a -> b) -> Dialog a -> Dialog b
+dialogMap applier (Dialog { title, icon } { body, buttons }) =
+    Dialog
+        { title = title
+        , icon = icon
+        }
+        { body = Element.map applier body
+        , buttons = List.map (Button.map applier) buttons
+        }
+
+
+withBody : Element msg -> Dialog msg -> Dialog msg
+withBody body (Dialog props options) =
+    Dialog props { options | body = body }
+
+
+withButtons : List (Button msg) -> Dialog msg -> Dialog msg
+withButtons buttons (Dialog props options) =
+    Dialog props { options | buttons = buttons }
+
+
+renderElement : RenderConfig -> Dialog msg -> Element msg
+renderElement cfg dialog =
+    desktopDialogView cfg dialog
+
+
+desktopDialogView : RenderConfig -> Dialog msg -> Element msg
+desktopDialogView cfg (Dialog { title, icon } { body, buttons }) =
+    Element.column
+        [ Element.width shrink
+        , Element.centerY
+        , Element.centerX
+        , PaletteInternal.mainBackground
+        , Element.padding 32
+        , Border.rounded 6
+        ]
+        [ desktopHeaderRow cfg title icon
+        , Element.el
+            [ Element.paddingEach
+                { top = 8
+                , bottom = 0
+                , left = 0
+                , right =
+                    0
+                }
+            ]
+            body
+        , Element.row
+            [ Element.spacing 16
+            , Element.paddingEach { top = 22, left = 0, right = 0, bottom = 0 }
+            ]
+          <|
+            List.map
+                (Button.renderElement cfg)
+                buttons
+        ]
+
+
+desktopHeaderRow : RenderConfig -> String -> Icon -> Element msg
+desktopHeaderRow cfg title icon =
+    Element.row
+        [ Element.spacing 12
+        , Element.width fill
+        ]
+        [ icon
+            |> Icon.withColor headerColor
+            |> Icon.renderElement cfg
+        , titleText cfg title
+        ]
+
+
+titleText : RenderConfig -> String -> Element msg
+titleText cfg title =
+    Text.heading5 title
+        |> Text.withColor headerColor
+        |> Text.renderElement cfg
+        |> Element.el
+            [ Element.width fill
+            ]
+
+
+headerColor : Palette.Color
+headerColor =
+    Palette.color Palette.toneGray Palette.brightnessMiddle

--- a/src/UI/V2/Dialog.elm
+++ b/src/UI/V2/Dialog.elm
@@ -10,7 +10,7 @@ import Element exposing (Element, fill, shrink)
 import Element.Border as Border
 import UI.Button as Button exposing (Button)
 import UI.Icon as Icon exposing (Icon)
-import UI.Internal.Palette as PaletteInternal
+import UI.Internal.Colors exposing (mainBackground)
 import UI.Palette as Palette
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Text as Text
@@ -65,7 +65,7 @@ desktopDialogView cfg (Dialog { title, icon } { body, buttons }) =
         [ Element.width shrink
         , Element.centerY
         , Element.centerX
-        , PaletteInternal.mainBackground
+        , mainBackground
         , Element.padding 32
         , Border.rounded 6
         ]

--- a/src/UI/V2/Dialog.elm
+++ b/src/UI/V2/Dialog.elm
@@ -1,11 +1,41 @@
 module UI.V2.Dialog exposing
-    ( Dialog(..)
-    , dialog
-    , dialogMap
+    ( Dialog(..), dialog
+    , withBody, withButtons
     , renderElement
-    , withBody
-    , withButtons
+    , dialogMap
     )
+
+{-| The `UI.V2.Dialog` is a component for displaying dialogs and modals.
+
+User must specify a title, an icon to be displayed in title and a close message
+to construct it. Body and buttons can be specified optionally as in the
+following pipeline:
+
+    dialog "Title" Icon.warning closeMsg
+        |> withBody ("Body text" |> Text.body2 |> Text.renderElement cfg)
+        |> withButtons buttons
+
+
+# Building
+
+@docs Dialog, dialog
+
+
+# Content
+
+@docs withBody, withButtons
+
+
+# Rendering
+
+@docs renderElement
+
+
+# Component handling
+
+@docs dialogMap
+
+-}
 
 import Element exposing (Element, fill, shrink)
 import Element.Border as Border
@@ -18,6 +48,13 @@ import UI.Text as Text
 import UI.Utils.Element as Element
 
 
+
+-- Building
+
+
+{-| The `Dialog msg` type is used for describing the component for later
+rendering.
+-}
 type Dialog msg
     = Dialog (Properties msg) (Options msg)
 
@@ -35,11 +72,20 @@ type alias Options msg =
     }
 
 
+{-| Constructs a dialog by receiving its title, icon in the title and a close
+message.
+-}
 dialog : String -> Icon -> msg -> Dialog msg
 dialog title icon closeMsg =
     Dialog (Properties title icon closeMsg) (Options Element.none [])
 
 
+
+-- Component handling
+
+
+{-| Transforms the message produced by the component.
+-}
 dialogMap : (a -> b) -> Dialog a -> Dialog b
 dialogMap applier (Dialog { title, icon, close } { body, buttons }) =
     Dialog
@@ -52,19 +98,41 @@ dialogMap applier (Dialog { title, icon, close } { body, buttons }) =
         }
 
 
+
+-- Content
+
+
+{-| With `Dialog.withBody` you can specify the body of the dialog.
+**Note**: By default, the body is `Element.none`
+-}
 withBody : Element msg -> Dialog msg -> Dialog msg
 withBody body (Dialog props options) =
     Dialog props { options | body = body }
 
 
+{-| With `Dialog.withButtons` you can specify the buttons for the footer of the
+dialog.
+**Note**: By default, the buttons are an empty list
+-}
 withButtons : List (Button msg) -> Dialog msg -> Dialog msg
 withButtons buttons (Dialog props options) =
     Dialog props { options | buttons = buttons }
 
 
+
+-- Rendering
+
+
+{-| End of the builder's life.
+The result of this function is a ready-to-insert Elm UI's Element.
+-}
 renderElement : RenderConfig -> Dialog msg -> Element msg
 renderElement cfg dlg =
     desktopDialogView cfg dlg
+
+
+
+-- Internal
 
 
 desktopDialogView : RenderConfig -> Dialog msg -> Element msg

--- a/src/UI/V2/Dialog.elm
+++ b/src/UI/V2/Dialog.elm
@@ -67,6 +67,7 @@ type alias Properties msg =
 type alias Options msg =
     { body : Element msg
     , buttons : List (Button msg)
+    , closeOnOverlayClick : Bool
     }
 
 
@@ -75,7 +76,7 @@ message.
 -}
 dialog : String -> Icon -> msg -> Dialog msg
 dialog title icon closeMsg =
-    Dialog (Properties title icon closeMsg) (Options Element.none [])
+    Dialog (Properties title icon closeMsg) (Options Element.none [] False)
 
 
 
@@ -85,7 +86,7 @@ dialog title icon closeMsg =
 {-| Transforms the message produced by the component.
 -}
 map : (a -> b) -> Dialog a -> Dialog b
-map applier (Dialog { title, icon, close } { body, buttons }) =
+map applier (Dialog { title, icon, close } { body, buttons, closeOnOverlayClick }) =
     Dialog
         { title = title
         , icon = icon
@@ -93,6 +94,7 @@ map applier (Dialog { title, icon, close } { body, buttons }) =
         }
         { body = Element.map applier body
         , buttons = List.map (Button.map applier) buttons
+        , closeOnOverlayClick = closeOnOverlayClick
         }
 
 
@@ -115,3 +117,16 @@ dialog.
 withButtons : List (Button msg) -> Dialog msg -> Dialog msg
 withButtons buttons (Dialog props options) =
     Dialog props { options | buttons = buttons }
+
+
+{-| Allows you to specify whether clicking on overlay closes the dialog or not.
+By default, clicking on overlay does nothing, that is because an unintentional
+click can cause loss of information if a dialog is open which is expecting an
+input from the user and user has already provided it partially. It is
+recommended to provide an explicit cancel/close button for such cases. However
+this helper can be used to recieve clicks on overlay to close the dialog where
+loss of information is not likely to happen.
+-}
+withCloseOnOverlayClick : Bool -> Dialog msg -> Dialog msg
+withCloseOnOverlayClick shouldClose (Dialog props options) =
+    Dialog props { options | closeOnOverlayClick = shouldClose }

--- a/src/UI/V2/Dialog.elm
+++ b/src/UI/V2/Dialog.elm
@@ -117,16 +117,3 @@ dialog.
 withButtons : List (Button msg) -> Dialog msg -> Dialog msg
 withButtons buttons (Dialog props options) =
     Dialog props { options | buttons = buttons }
-
-
-{-| Allows you to specify whether clicking on overlay closes the dialog or not.
-By default, clicking on overlay does nothing, that is because an unintentional
-click can cause loss of information if a dialog is open which is expecting an
-input from the user and user has already provided it partially. It is
-recommended to provide an explicit cancel/close button for such cases. However
-this helper can be used to recieve clicks on overlay to close the dialog where
-loss of information is not likely to happen.
--}
-withCloseOnOverlayClick : Bool -> Dialog msg -> Dialog msg
-withCloseOnOverlayClick shouldClose (Dialog props options) =
-    Dialog props { options | closeOnOverlayClick = shouldClose }


### PR DESCRIPTION
#### :thinking: What?
Adds another Dialog component as discussed in this [RFC](https://paacklogistics.atlassian.net/wiki/spaces/EN/pages/2089025545/New+Dialog+API),


#### :man_shrugging: Why?
Check out the RFC


#### :pushpin: Jira Issue
[WMS-715](https://paacklogistics.atlassian.net/browse/WMS-715)


### :fire: Extra
I have made icon in the title as mandatory to create this version of the dialog and removed close message as an argument since this version of the dialog is not going to have a cross button to close the dialog nor it will have the overlay. Have a look at [this conversation](https://www.figma.com/file/DTyoSveNksHpZCdU8a7BNs?node-id=369:29#50879134) regarding the title in the icon and removal of the cross button.
