### PR TITLE
Disable elm-debugging in Percy

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -39,6 +39,7 @@ jobs:
          with:
           start: yarn showcase
           wait-on: 'http://localhost:1234'
-          command-prefix: 'percy exec -- env NODE_ENV=production'
+          command-prefix: 'percy exec --'
          env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          NODE_ENV: 'production'

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -42,3 +42,4 @@ jobs:
           command-prefix: 'percy exec --'
          env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          ELM_DEBUGGER: 'false'

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -39,7 +39,6 @@ jobs:
          with:
           start: yarn showcase
           wait-on: 'http://localhost:1234'
-          command-prefix: 'percy exec --'
+          command-prefix: 'percy exec -- env NODE_ENV=production'
          env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          NODE_ENV: 'production'

--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -42,4 +42,4 @@ jobs:
           command-prefix: 'percy exec --'
          env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          ELM_DEBUGGER: 'false'
+          NODE_ENV: 'production'

--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     "node-elm-compiler": "^5.0.4",
     "paack-ui-assets": "^0.0.12",
     "parcel-bundler": "^1.12.4",
-    "parcel-plugin-asset-copier": "^1.1.0"
-  },
-  "devDependencies": {
+    "parcel-plugin-asset-copier": "^1.1.0",
     "@percy/cypress": "^2.3.2",
     "cypress": "^5.6.0",
     "elm-format": "^0.8.3",


### PR DESCRIPTION
#### :thinking: What?

- Keep Elm' debugger out of Percy's screenshots.


#### :man_shrugging: Why?

- It was meddling with reviewing.


#### :pushpin: Jira Issue

Not tracked.


#### :no_good: Blocked by

Not blocked.


#### :clipboard: Pending

- To discover if it works!
