### PR TITLE
Remve UI.V2.Dialog from elm.json causing elm-analyse to fail

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -29,8 +29,7 @@
         "UI.Utils.ARIA",
         "UI.Utils.Element",
         "UI.Utils.Focus",
-        "UI.Utils.TypeNumbers",
-        "UI.V2.Dialog"
+        "UI.Utils.TypeNumbers"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/src/UI/Internal/DialogV2.elm
+++ b/src/UI/Internal/DialogV2.elm
@@ -13,10 +13,10 @@ import UI.Size as Size
 import UI.Text as Text
 import UI.Utils.ARIA as ARIA exposing (roleButton)
 import UI.Utils.Element as Element
-import UI.V2.Dialog as Dialog exposing (Dialog)
+import UI.V2.Dialog as Dialog
 
 
-dialogViewV2 : RenderConfig -> Dialog msg -> Element msg
+dialogViewV2 : RenderConfig -> Dialog.Dialog msg -> Element msg
 dialogViewV2 cfg ((Dialog.Dialog { close } { closeOnOverlayClick }) as dlg) =
     if RenderConfig.isMobile cfg then
         mobileView cfg dlg
@@ -30,7 +30,7 @@ dialogViewV2 cfg ((Dialog.Dialog { close } { closeOnOverlayClick }) as dlg) =
                 ]
 
 
-desktopDialogView : RenderConfig -> Dialog msg -> Element msg
+desktopDialogView : RenderConfig -> Dialog.Dialog msg -> Element msg
 desktopDialogView cfg (Dialog.Dialog { title, icon } { body, buttons }) =
     Element.column
         [ Element.width shrink
@@ -90,7 +90,7 @@ desktopHeaderRow cfg title icon =
         ]
 
 
-mobileView : RenderConfig -> Dialog msg -> Element msg
+mobileView : RenderConfig -> Dialog.Dialog msg -> Element msg
 mobileView cfg (Dialog.Dialog { title, close } { body, buttons }) =
     Element.column
         [ Element.width fill

--- a/src/UI/NavigationContainer.elm
+++ b/src/UI/NavigationContainer.elm
@@ -82,10 +82,8 @@ Example of usage:
 -}
 
 import Element exposing (Element, fill)
-import Element.Events as Events
 import Html exposing (Html)
 import UI.Icon as Icon exposing (Icon)
-import UI.Internal.Colors as Colors
 import UI.Internal.Dialog as Dialog1
 import UI.Internal.DialogV2 exposing (dialogViewV2)
 import UI.Internal.Menu as Menu
@@ -514,7 +512,7 @@ toBrowserDocument cfg page (Navigator model) =
                 Just (Dialog1 dialogState) ->
                     Dialog1.view cfg dialogState
 
-                Just (Dialog2 ((Dialog2.Dialog { close } { closeOnOverlayClick }) as dialogState)) ->
+                Just (Dialog2 dialogState) ->
                     dialogState
                         |> dialogViewV2 cfg
 

--- a/src/UI/V2/Dialog.elm
+++ b/src/UI/V2/Dialog.elm
@@ -31,18 +31,9 @@ following pipeline:
 
 -}
 
-import Element exposing (Element, fill, shrink)
-import Element.Border as Border
-import Element.Events as Events
+import Element exposing (Element)
 import UI.Button as Button exposing (Button)
-import UI.Icon as Icon exposing (Icon)
-import UI.Internal.Colors exposing (mainBackground)
-import UI.Internal.RenderConfig exposing (RenderConfig, localeTerms)
-import UI.Palette as Palette
-import UI.RenderConfig as RenderConfig exposing (RenderConfig)
-import UI.Size as Size
-import UI.Text as Text
-import UI.Utils.ARIA as ARIA exposing (roleButton)
+import UI.Icon exposing (Icon)
 import UI.Utils.Element as Element
 
 


### PR DESCRIPTION
#### :thinking: What?
Remove exposed module `UI.V2.Dialog` from elm.json and fix elm-analyse issues


#### :man_shrugging: Why?
Since it was causing elm-analyse to crash due to [this bug](https://github.com/stil4m/elm-analyse/issues/198).
