### PR TITLE
Disables auto-rebasing for dependabot's PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,14 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  rebase-strategy: "disabled"
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
+  rebase-strategy: "disabled"
 - package-ecosystem: elm
   directory: "/"
   schedule:
     interval: daily
+  rebase-strategy: "disabled"


### PR DESCRIPTION
#### :thinking: What?

* Disables auto-rebasing for dependabot's PRs


#### :man_shrugging: Why?

* It's wasting CI and GH Actions resources;
* It's delaying higher-priority rebases.


#### :pushpin: Jira Issue

Not tracked


#### :no_good: Blocked by

Not blocked.


#### :clipboard: Pending

Nothing