### PR TITLE
Do not run Percy when PR is a draft

### DIFF
--- a/.github/workflows/percy.yml
+++ b/.github/workflows/percy.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   percy:
      runs-on: ubuntu-latest
+     if: github.event.pull_request.draft == false
 
      steps:
        - uses: actions/checkout@v2


### PR DESCRIPTION
#### :thinking: What?

* Do not run Percy when PR is a draft


#### :man_shrugging: Why?

* Drafts are mostly POC and we don't want to waste our free screenshots, changing it to non-draft reenables Percy and other CIs, and that is required before merging...


#### :pushpin: Jira Issue

Not tracked.


#### :no_good: Blocked by

Not blocked.


#### :clipboard: Pending

Nothing at all.