### PR TITLE
DES-29 ⊕ WMS-652 | Table sort

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,5 +16,9 @@ trim_trailing_whitespace = false
 indent_style = space
 indent_size = 4
 
+[i18n/*.json]
+indent_size = 4
+insert_final_newline = false
+
 [COMMIT_EDITMSG]
 max_line_length = 0

--- a/i18n/English.json
+++ b/i18n/English.json
@@ -40,7 +40,9 @@
         "sorting": {
             "increase": "Sort from A - Z",
             "decrease": "Sort from Z - A"
-        }
+        },
+        "selectRow": "Select this row.",
+        "selectAll": "Select all rows"
     },
     "dateInput": {
         "invalid": "Invalid date format."

--- a/i18n/English.json
+++ b/i18n/English.json
@@ -15,11 +15,11 @@
             "to": "To: {{date}}"
         },
         "select": {
-            "description": "Select option for filtering" 
+            "description": "Select option for filtering"
         }
     },
     "paginator": {
-        "format": "{{first}} - {{last}} of {{total}}", 
+        "format": "{{first}} - {{last}} of {{total}}",
         "previous": "Previous",
         "next": "Next"
     },
@@ -34,8 +34,12 @@
     },
     "tables": {
         "details": {
-            "show" : "Expand",
+            "show": "Expand",
             "collapse": "Collapse"
+        },
+        "sorting": {
+            "increase": "Sort from A - Z",
+            "decrease": "Sort from Z - A"
         }
     },
     "dateInput": {

--- a/i18n/French.json
+++ b/i18n/French.json
@@ -1,6 +1,6 @@
 {
     "filters": {
-        "dateFormat": "DD/MM/YYYY",
+        "dateFormat": "JJ/MM/AAAA",
         "close": "Fermer",
         "clear": "Effacer",
         "apply": "Appliquer",
@@ -36,6 +36,10 @@
         "details": {
             "show": "Elargir",
             "collapse": "Crash"
+        },
+        "sorting": {
+            "increase": "Sort from A - Z",
+            "decrease": "Sort from Z - A"
         }
     },
     "dateInput": {

--- a/i18n/French.json
+++ b/i18n/French.json
@@ -40,7 +40,9 @@
         "sorting": {
             "increase": "Trier de A à Z",
             "decrease": "Trier de Z à A"
-        }
+        },
+        "selectRow": "Select this row.",
+        "selectAll": "Select all rows"
     },
     "dateInput": {
         "invalid": "Format de date invalide"

--- a/i18n/French.json
+++ b/i18n/French.json
@@ -1,6 +1,6 @@
 {
     "filters": {
-        "dateFormat": "JJ/MM/AAAA",
+        "dateFormat": "DD/MM/YYYY",
         "close": "Fermer",
         "clear": "Effacer",
         "apply": "Appliquer",

--- a/i18n/French.json
+++ b/i18n/French.json
@@ -38,8 +38,8 @@
             "collapse": "Crash"
         },
         "sorting": {
-            "increase": "Sort from A - Z",
-            "decrease": "Sort from Z - A"
+            "increase": "Trier de A à Z",
+            "decrease": "Trier de Z à A"
         }
     },
     "dateInput": {

--- a/i18n/French.json
+++ b/i18n/French.json
@@ -41,8 +41,8 @@
             "increase": "Trier de A à Z",
             "decrease": "Trier de Z à A"
         },
-        "selectRow": "Select this row.",
-        "selectAll": "Select all rows"
+        "selectRow": "Sélectionner la ligne",
+        "selectAll": "Sélectionner toutes les lignes"
     },
     "dateInput": {
         "invalid": "Format de date invalide"

--- a/i18n/Spanish.json
+++ b/i18n/Spanish.json
@@ -40,7 +40,9 @@
         "sorting": {
             "increase": "Ordenar A-Z",
             "decrease": "Ordenar Z-A"
-        }
+        },
+        "selectRow": "Select this row.",
+        "selectAll": "Select all rows"
     },
     "dateInput": {
         "invalid": "Formato de fecha inválido"

--- a/i18n/Spanish.json
+++ b/i18n/Spanish.json
@@ -1,1 +1,56 @@
-English.json
+{
+    "filters": {
+        "dateFormat": "DD/MM/YYYY",
+        "close": "Cerrar",
+        "clear": "Limpiar",
+        "apply": "Aplicar",
+        "period": {
+            "after": "Después",
+            "before": "Antes",
+            "on": "En",
+            "description": "Seleccionar período de referencia"
+        },
+        "range": {
+            "from": "Desde: {{date}}",
+            "to": "Hasta: {{date}}"
+        },
+        "select": {
+            "description": "Seleccionar opción para filtrar"
+        }
+    },
+    "paginator": {
+        "format": "{{first}} - {{last}} de {{total}}",
+        "previous": "Anterior",
+        "next": "Siguiente"
+    },
+    "checkbox": {
+        "toggle": "Agrupar"
+    },
+    "listView": {
+        "search": "Buscar"
+    },
+    "radio": {
+        "select": "Seleccionar item"
+    },
+    "tables": {
+        "details": {
+            "show": "Expandir",
+            "collapse": "Colapsar"
+        },
+        "sorting": {
+            "increase": "Ordenar A-Z",
+            "decrease": "Ordenar Z-A"
+        }
+    },
+    "dateInput": {
+        "invalid": "Formato de fecha inválido"
+    },
+    "dialog": {
+        "close": "Cerrar dialogo"
+    },
+    "sidebar": {
+        "expand": "Expandir barra lateral",
+        "collapse": "Minimizar barra lateral",
+        "previous": "Atrás"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "elm-format": "^0.8.5",
     "elm-hot": "^1.1.6",
     "elm-test": "^0.19.1-revision6",
-    "i18n-json-to-elm": "PedroHLC/i18n-json-to-elm",
+    "i18n-json-to-elm": "^1.1.2",
     "node-elm-compiler": "^5.0.4",
     "paack-ui-assets": "^0.0.13",
     "parcel-bundler": "^1.12.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "elm-test": "^0.19.1-revision6",
     "i18n-json-to-elm": "^1.1.2",
     "node-elm-compiler": "^5.0.4",
-    "paack-ui-assets": "^0.0.13",
+    "paack-ui-assets": "PaackEng/paack-ui-assets#0.1.0",
     "parcel-bundler": "^1.12.4",
     "parcel-plugin-asset-copier": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "elm-test": "^0.19.1-revision6",
     "i18n-json-to-elm": "^1.1.2",
     "node-elm-compiler": "^5.0.4",
-    "paack-ui-assets": "PaackEng/paack-ui-assets#0.1.0",
+    "paack-ui-assets": "^0.1.0",
     "parcel-bundler": "^1.12.4",
     "parcel-plugin-asset-copier": "^1.1.0"
   },

--- a/showcase/src/Tables/Book.elm
+++ b/showcase/src/Tables/Book.elm
@@ -1,7 +1,8 @@
 module Tables.Book exposing
     ( Book
     , books
-    , someFilters
+    , filters
+    , sorters
     , tablePixelColumns
     , tablePortionColumns
     , toTableCover
@@ -9,7 +10,7 @@ module Tables.Book exposing
     , toTableRow
     )
 
-import Time exposing (millisToPosix)
+import Time exposing (millisToPosix, posixToMillis)
 import UI.Internal.DateInput as DateInput
 import UI.Tables.Common as Tables exposing (cellFromText, column, columnWidthPixels, columnWidthPortion, columnsEmpty, rowCellText, rowEmpty)
 import UI.Tables.Stateful as Stateful exposing (detailHidden, detailShown, detailsEmpty)
@@ -27,8 +28,8 @@ type alias Book =
     }
 
 
-someFilters : Stateful.Filters msg Book T.Five
-someFilters =
+filters : Stateful.Filters msg Book T.Five
+filters =
     Stateful.filtersEmpty
         |> Stateful.localMultiTextFilter [] .title
         |> Stateful.localMultiTextFilter [] .author
@@ -51,6 +52,16 @@ someFilters =
             )
         |> Stateful.localRangeDateFilter Time.utc Nothing Nothing .acquired
         |> Stateful.localPeriodDateFilter Time.utc Nothing Nothing .read
+
+
+sorters : Stateful.Sorters Book T.Five
+sorters =
+    Stateful.sortersEmpty
+        |> Stateful.sortBy .title
+        |> Stateful.sortBy .author
+        |> Stateful.sortBy .year
+        |> Stateful.sortBy (.acquired >> posixToMillis >> String.fromInt)
+        |> Stateful.sortBy (.read >> posixToMillis >> String.fromInt)
 
 
 books : List Book

--- a/showcase/src/Tables/Model.elm
+++ b/showcase/src/Tables/Model.elm
@@ -24,4 +24,5 @@ initModel =
             |> Table.stateWithSelection .isbn False
             |> Table.stateWithFilters Book.filters
             |> Table.stateWithSorters Book.sorters
+            |> Table.stateWithItems Book.books
     }

--- a/showcase/src/Tables/Model.elm
+++ b/showcase/src/Tables/Model.elm
@@ -16,10 +16,12 @@ initModel : Model
 initModel =
     { mainTableState =
         Table.init
-            |> Table.stateWithFilters Book.someFilters
+            |> Table.stateWithFilters Book.filters
+            |> Table.stateWithSorters Book.sorters
             |> Table.stateWithItems Book.books
     , selecTableState =
         Table.init
             |> Table.stateWithSelection .isbn False
-            |> Table.stateWithFilters Book.someFilters
+            |> Table.stateWithFilters Book.filters
+            |> Table.stateWithSorters Book.sorters
     }

--- a/showcase/src/Tables/Model.elm
+++ b/showcase/src/Tables/Model.elm
@@ -1,7 +1,7 @@
 module Tables.Model exposing (Model, initModel)
 
 import Msg exposing (Msg)
-import Tables.Book exposing (..)
+import Tables.Book as Book exposing (Book)
 import UI.Tables.Stateful as Table
 import UI.Utils.TypeNumbers exposing (Five)
 
@@ -16,9 +16,10 @@ initModel : Model
 initModel =
     { mainTableState =
         Table.init
-            |> Table.stateWithFilters someFilters
+            |> Table.stateWithFilters Book.someFilters
+            |> Table.stateWithItems Book.books
     , selecTableState =
         Table.init
             |> Table.stateWithSelection .isbn False
-            |> Table.stateWithFilters someFilters
+            |> Table.stateWithFilters Book.someFilters
     }

--- a/showcase/src/Tables/Stories.elm
+++ b/showcase/src/Tables/Stories.elm
@@ -98,7 +98,6 @@ demoTable renderConfig columns state msg =
             , toCover = Book.toTableCover
             }
         |> Stateful.withWidth Element.shrink
-        |> Stateful.withItems Book.books
         |> Stateful.renderElement renderConfig
 
 

--- a/src/I18n/English.elm
+++ b/src/I18n/English.elm
@@ -70,9 +70,17 @@ tablesDetails =
     }
 
 
+tablesSorting : TablesSorting
+tablesSorting =
+    { increase = "Sort from A - Z"
+    , decrease = "Sort from Z - A"
+    }
+
+
 tables : Tables
 tables =
     { details = tablesDetails
+    , sorting = tablesSorting
     }
 
 

--- a/src/I18n/English.elm
+++ b/src/I18n/English.elm
@@ -81,6 +81,8 @@ tables : Tables
 tables =
     { details = tablesDetails
     , sorting = tablesSorting
+    , selectRow = "Select this row."
+    , selectAll = "Select all rows"
     }
 
 

--- a/src/I18n/French.elm
+++ b/src/I18n/French.elm
@@ -27,7 +27,7 @@ filtersSelect =
 
 filters : Filters
 filters =
-    { dateFormat = "JJ/MM/AAAA"
+    { dateFormat = "DD/MM/YYYY"
     , close = "Fermer"
     , clear = "Effacer"
     , apply = "Appliquer"

--- a/src/I18n/French.elm
+++ b/src/I18n/French.elm
@@ -27,7 +27,7 @@ filtersSelect =
 
 filters : Filters
 filters =
-    { dateFormat = "DD/MM/YYYY"
+    { dateFormat = "JJ/MM/AAAA"
     , close = "Fermer"
     , clear = "Effacer"
     , apply = "Appliquer"
@@ -70,9 +70,17 @@ tablesDetails =
     }
 
 
+tablesSorting : TablesSorting
+tablesSorting =
+    { increase = "Sort from A - Z"
+    , decrease = "Sort from Z - A"
+    }
+
+
 tables : Tables
 tables =
     { details = tablesDetails
+    , sorting = tablesSorting
     }
 
 

--- a/src/I18n/French.elm
+++ b/src/I18n/French.elm
@@ -72,8 +72,8 @@ tablesDetails =
 
 tablesSorting : TablesSorting
 tablesSorting =
-    { increase = "Sort from A - Z"
-    , decrease = "Sort from Z - A"
+    { increase = "Trier de A à Z"
+    , decrease = "Trier de Z à A"
     }
 
 
@@ -81,6 +81,8 @@ tables : Tables
 tables =
     { details = tablesDetails
     , sorting = tablesSorting
+    , selectRow = "Select this row."
+    , selectAll = "Select all rows"
     }
 
 

--- a/src/I18n/Spanish.elm
+++ b/src/I18n/Spanish.elm
@@ -70,9 +70,17 @@ tablesDetails =
     }
 
 
+tablesSorting : TablesSorting
+tablesSorting =
+    { increase = "Sort from A - Z"
+    , decrease = "Sort from Z - A"
+    }
+
+
 tables : Tables
 tables =
     { details = tablesDetails
+    , sorting = tablesSorting
     }
 
 

--- a/src/I18n/Spanish.elm
+++ b/src/I18n/Spanish.elm
@@ -81,6 +81,8 @@ tables : Tables
 tables =
     { details = tablesDetails
     , sorting = tablesSorting
+    , selectRow = "Select this row."
+    , selectAll = "Select all rows"
     }
 
 

--- a/src/I18n/Spanish.elm
+++ b/src/I18n/Spanish.elm
@@ -5,32 +5,32 @@ import I18n.Types exposing (..)
 
 filtersPeriod : FiltersPeriod
 filtersPeriod =
-    { after = "After"
-    , before = "Before"
-    , on = "On"
-    , description = "Select period reference"
+    { after = "Después"
+    , before = "Antes"
+    , on = "En"
+    , description = "Seleccionar período de referencia"
     }
 
 
 filtersRange : FiltersRange
 filtersRange =
-    { from = \{ date } -> "From: " ++ date ++ ""
-    , to = \{ date } -> "To: " ++ date ++ ""
+    { from = \{ date } -> "Desde: " ++ date ++ ""
+    , to = \{ date } -> "Hasta: " ++ date ++ ""
     }
 
 
 filtersSelect : FiltersSelect
 filtersSelect =
-    { description = "Select option for filtering"
+    { description = "Seleccionar opción para filtrar"
     }
 
 
 filters : Filters
 filters =
     { dateFormat = "DD/MM/YYYY"
-    , close = "Close"
-    , clear = "Clear"
-    , apply = "Apply"
+    , close = "Cerrar"
+    , clear = "Limpiar"
+    , apply = "Aplicar"
     , period = filtersPeriod
     , range = filtersRange
     , select = filtersSelect
@@ -39,41 +39,41 @@ filters =
 
 paginator : Paginator
 paginator =
-    { format = \{ first, last, total } -> "" ++ first ++ " - " ++ last ++ " of " ++ total ++ ""
-    , previous = "Previous"
-    , next = "Next"
+    { format = \{ first, last, total } -> "" ++ first ++ " - " ++ last ++ " de " ++ total ++ ""
+    , previous = "Anterior"
+    , next = "Siguiente"
     }
 
 
 checkbox : Checkbox
 checkbox =
-    { toggle = "Toggle"
+    { toggle = "Agrupar"
     }
 
 
 listView : ListView
 listView =
-    { search = "Search"
+    { search = "Buscar"
     }
 
 
 radio : Radio
 radio =
-    { select = "Select item"
+    { select = "Seleccionar item"
     }
 
 
 tablesDetails : TablesDetails
 tablesDetails =
-    { show = "Expand"
-    , collapse = "Collapse"
+    { show = "Expandir"
+    , collapse = "Colapsar"
     }
 
 
 tablesSorting : TablesSorting
 tablesSorting =
-    { increase = "Sort from A - Z"
-    , decrease = "Sort from Z - A"
+    { increase = "Ordenar A-Z"
+    , decrease = "Ordenar Z-A"
     }
 
 
@@ -86,21 +86,21 @@ tables =
 
 dateInput : DateInput
 dateInput =
-    { invalid = "Invalid date format."
+    { invalid = "Formato de fecha inválido"
     }
 
 
 dialog : Dialog
 dialog =
-    { close = "Close dialog"
+    { close = "Cerrar dialogo"
     }
 
 
 sidebar : Sidebar
 sidebar =
-    { expand = "Expand sidebar"
-    , collapse = "Minimize sidebar"
-    , previous = "Go back"
+    { expand = "Expandir barra lateral"
+    , collapse = "Minimizar barra lateral"
+    , previous = "Atrás"
     }
 
 

--- a/src/I18n/Types.elm
+++ b/src/I18n/Types.elm
@@ -59,8 +59,15 @@ type alias TablesDetails =
     }
 
 
+type alias TablesSorting =
+    { increase : String
+    , decrease : String
+    }
+
+
 type alias Tables =
     { details : TablesDetails
+    , sorting : TablesSorting
     }
 
 

--- a/src/I18n/Types.elm
+++ b/src/I18n/Types.elm
@@ -68,6 +68,8 @@ type alias TablesSorting =
 type alias Tables =
     { details : TablesDetails
     , sorting : TablesSorting
+    , selectRow : String
+    , selectAll : String
     }
 
 

--- a/src/UI/Icon.elm
+++ b/src/UI/Icon.elm
@@ -5,6 +5,7 @@ module UI.Icon exposing
     , groups, logout, move, nextContent, notifications, paackSpaces, packages
     , previousContent, print, remove, sandwichMenu, search, searchSpace
     , seeMore, toggle, toggleDown, toggleUp, delete, warning
+    , sortDecreasing, sortIncreasing
     , getHint
     , withColor
     , withSize, withCustomSize
@@ -39,6 +40,7 @@ An icon can be created and rendered as in the following pipeline:
 @docs groups, logout, move, nextContent, notifications, paackSpaces, packages
 @docs previousContent, print, remove, sandwichMenu, search, searchSpace
 @docs seeMore, toggle, toggleDown, toggleUp, delete, warning
+@docs sortDecreasing, sortIncreasing
 
 
 # Disassemble
@@ -96,11 +98,14 @@ type Icon
     = Icon Properties Options
 
 
-type IconGlyph
+type
+    IconGlyph
+    -- When addig, name the icons as "actions" and not what they look like
     = Add
     | Check
     | Close
     | Collapse
+    | Delete
     | DownArrow
     | Download
     | Edit
@@ -108,22 +113,23 @@ type IconGlyph
     | Expand
     | Filter
     | Groups
-    | LeftArrow
     | Logout
     | Move
+    | NextContent
     | Notifications
     | PaackSpaces
     | Packages
+    | PreviousContent
     | Print
     | Remove
-    | RightArrow
     | SandwichMenu
     | Search
     | SearchSpace
     | SeeMore
+    | SortDecreasing
+    | SortIncreasing
     | Toggle
-    | Delete
-    | UpArrow
+    | ToggleUp
     | Warning
 
 
@@ -185,7 +191,7 @@ withCustomSize size (Icon prop opt) =
 -}
 previousContent : String -> Icon
 previousContent hint =
-    Icon (Properties hint LeftArrow) defaultOptions
+    Icon (Properties hint PreviousContent) defaultOptions
 
 
 {-| An arrow pointing to the right used in chevrons and paginators.
@@ -195,7 +201,7 @@ previousContent hint =
 -}
 nextContent : String -> Icon
 nextContent hint =
-    Icon (Properties hint RightArrow) defaultOptions
+    Icon (Properties hint NextContent) defaultOptions
 
 
 {-| A foldable paper, toggle some content between showing/hiding, or full/collapsed.
@@ -216,7 +222,7 @@ May indicate the collapsing of the content below.
 -}
 toggleUp : String -> Icon
 toggleUp hint =
-    Icon (Properties hint UpArrow) defaultOptions
+    Icon (Properties hint ToggleUp) defaultOptions
 
 
 {-| An arrow pointing down.
@@ -464,6 +470,26 @@ move hint =
     Icon (Properties hint Move) defaultOptions
 
 
+{-| An arrow pointing down.
+
+    Icon.sortIncreasing "Sort from A to Z"
+
+-}
+sortIncreasing : String -> Icon
+sortIncreasing hint =
+    Icon (Properties hint SortIncreasing) defaultOptions
+
+
+{-| An arrow pointing up.
+
+    Icon.sortDecreasing "Sort from Z to A"
+
+-}
+sortDecreasing : String -> Icon
+sortDecreasing hint =
+    Icon (Properties hint SortDecreasing) defaultOptions
+
+
 
 -- Rendering
 
@@ -508,6 +534,9 @@ renderElement _ (Icon { hint, glyph } { color, size }) =
             Collapse ->
                 svgIcon "Collapse"
 
+            Delete ->
+                svgIcon "Trash"
+
             DownArrow ->
                 svgIcon "Chevron.Down"
 
@@ -529,11 +558,14 @@ renderElement _ (Icon { hint, glyph } { color, size }) =
             Groups ->
                 svgIcon "Groups"
 
-            LeftArrow ->
-                svgIcon "Chevron.Left"
-
             Logout ->
                 svgIcon "Logout"
+
+            Move ->
+                svgIcon "Move"
+
+            NextContent ->
+                svgIcon "Chevron.Right"
 
             Notifications ->
                 svgIcon "Bell"
@@ -544,14 +576,14 @@ renderElement _ (Icon { hint, glyph } { color, size }) =
             Packages ->
                 svgIcon "Box.Outlined"
 
+            PreviousContent ->
+                svgIcon "Chevron.Left"
+
             Print ->
                 svgIcon "Printer"
 
             Remove ->
                 svgIcon "Remove"
-
-            RightArrow ->
-                svgIcon "Chevron.Right"
 
             SandwichMenu ->
                 svgIcon "Hamburger"
@@ -565,20 +597,20 @@ renderElement _ (Icon { hint, glyph } { color, size }) =
             SeeMore ->
                 svgIcon "Ellipsis"
 
+            SortDecreasing ->
+                svgIcon "Arrow.Up"
+
+            SortIncreasing ->
+                svgIcon "Arrow.Down"
+
             Toggle ->
                 svgIcon "Map"
 
-            UpArrow ->
+            ToggleUp ->
                 svgIcon "Chevron.Up"
 
             Warning ->
                 svgIcon "Warning"
-
-            Delete ->
-                svgIcon "Trash"
-
-            Move ->
-                svgIcon "Move"
 
 
 

--- a/src/UI/Icon.elm
+++ b/src/UI/Icon.elm
@@ -98,9 +98,10 @@ type Icon
     = Icon Properties Options
 
 
-type
-    IconGlyph
-    -- When addig, name the icons as "actions" and not what they look like
+{-| When addig new icons, name them as "actions" and not what they look like.
+For more information read this module's main documentation.
+-}
+type IconGlyph
     = Add
     | Check
     | Close

--- a/src/UI/Icon.elm
+++ b/src/UI/Icon.elm
@@ -538,7 +538,7 @@ renderElement _ (Icon { hint, glyph } { color, size }) =
                 svgIcon "Trash"
 
             DownArrow ->
-                svgIcon "Chevron.Down"
+                svgIcon "Chevron-Down"
 
             Download ->
                 svgIcon "Download"
@@ -565,7 +565,7 @@ renderElement _ (Icon { hint, glyph } { color, size }) =
                 svgIcon "Move"
 
             NextContent ->
-                svgIcon "Chevron.Right"
+                svgIcon "Chevron-Right"
 
             Notifications ->
                 svgIcon "Bell"
@@ -574,10 +574,10 @@ renderElement _ (Icon { hint, glyph } { color, size }) =
                 svgIcon "Space"
 
             Packages ->
-                svgIcon "Box.Outlined"
+                svgIcon "Box-Outlined"
 
             PreviousContent ->
-                svgIcon "Chevron.Left"
+                svgIcon "Chevron-Left"
 
             Print ->
                 svgIcon "Printer"
@@ -592,22 +592,22 @@ renderElement _ (Icon { hint, glyph } { color, size }) =
                 svgIcon "Search"
 
             SearchSpace ->
-                svgIcon "Space.Search"
+                svgIcon "Space-Search"
 
             SeeMore ->
                 svgIcon "Ellipsis"
 
             SortDecreasing ->
-                svgIcon "Arrow.Up"
+                svgIcon "Arrow-Up"
 
             SortIncreasing ->
-                svgIcon "Arrow.Down"
+                svgIcon "Arrow-Down"
 
             Toggle ->
                 svgIcon "Map"
 
             ToggleUp ->
-                svgIcon "Chevron.Up"
+                svgIcon "Chevron-Up"
 
             Warning ->
                 svgIcon "Warning"

--- a/src/UI/Internal/Basics.elm
+++ b/src/UI/Internal/Basics.elm
@@ -1,4 +1,4 @@
-module UI.Internal.Basics exposing (flip, ifThenElse, lazyMap, maybeAnd, maybeNotThen, pairUncurry, prependMaybe)
+module UI.Internal.Basics exposing (flip, ifThenElse, lazyMap, maybeAnd, maybeNotThen, maybeThen, pairUncurry, prependMaybe)
 
 
 prependMaybe : Maybe a -> List a -> List a
@@ -52,3 +52,13 @@ maybeAnd condition value =
 flip : (a -> b -> c) -> b -> a -> c
 flip applier b a =
     applier a b
+
+
+maybeThen : (a -> b -> b) -> Maybe a -> b -> b
+maybeThen applier maybeValue etc =
+    case maybeValue of
+        Just value ->
+            applier value etc
+
+        Nothing ->
+            etc

--- a/src/UI/Internal/Basics.elm
+++ b/src/UI/Internal/Basics.elm
@@ -1,4 +1,4 @@
-module UI.Internal.Basics exposing (flip, ifThenElse, lazyMap, maybeAnd, maybeNotThen, maybeThen, pairUncurry, prependMaybe)
+module UI.Internal.Basics exposing (..)
 
 
 prependMaybe : Maybe a -> List a -> List a
@@ -9,6 +9,15 @@ prependMaybe maybeSomething items =
 
         Nothing ->
             items
+
+
+prependIf : Bool -> a -> List a -> List a
+prependIf condition something items =
+    if condition then
+        something :: items
+
+    else
+        items
 
 
 lazyMap : (a -> b) -> (c -> a) -> (c -> b)

--- a/src/UI/Internal/Tables/Filters.elm
+++ b/src/UI/Internal/Tables/Filters.elm
@@ -19,6 +19,7 @@ module UI.Internal.Tables.Filters exposing
     , filtersReduce
     , isApplied
     , isEdited
+    , itemsApplyFilters
     , multiTextLocal
     , multiTextRemote
     , periodDateLocal
@@ -58,6 +59,14 @@ type Msg
 
 type alias Filters msg item columns =
     NArray (Filter msg item) columns
+
+
+itemsApplyFilters filters items =
+    filters
+        |> NArray.toList
+        |> List.filterMap filterGet
+        |> List.foldl filtersReduce (always True)
+        |> flip List.filter items
 
 
 

--- a/src/UI/Internal/Tables/Filters.elm
+++ b/src/UI/Internal/Tables/Filters.elm
@@ -61,6 +61,7 @@ type alias Filters msg item columns =
     NArray (Filter msg item) columns
 
 
+itemsApplyFilters : Filters msg item columns -> List item -> List item
 itemsApplyFilters filters items =
     filters
         |> NArray.toList

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -101,7 +101,8 @@ header renderConfig filter sorting config =
 
 headerSelectToggle : RenderConfig -> msg -> Element msg
 headerSelectToggle renderConfig toggleMsg =
-    Icon.check ""
+    (localeTerms renderConfig |> .tables |> .selectAll)
+        |> Icon.check
         |> Icon.withSize contextSize
         |> Icon.renderElement renderConfig
         |> Element.el

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -359,13 +359,13 @@ sortAs renderConfig { fromSortersMsg, index } direction current =
             current == Just (Just direction)
     in
     Element.row
-        (ARIA.toElementAttributes ARIA.roleButton
+        (Events.onClick (fromSortersMsg <| Sorters.SetSorting index direction)
+            :: Element.pointer
             :: Element.width fill
             :: Element.paddingEach { top = 4, left = 12, bottom = 4, right = 8 }
             :: Border.color Colors.gray.lighter
             :: Border.widthEach { zeroPadding | bottom = 1 }
-            :: Element.pointer
-            :: Events.onClick (fromSortersMsg <| Sorters.SetSorting index direction)
+            :: ARIA.toElementAttributes ARIA.roleButton
             |> prependIf selected (Background.color <| Colors.gray.lightest)
         )
         [ Text.caption content

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -119,29 +119,23 @@ headerSelectToggle renderConfig toggleMsg =
 headerNormal : RenderConfig -> msg -> String -> Sorters.ColumnStatus -> Element msg
 headerNormal renderConfig openMsg label sorting =
     -- Button.light
-    Element.row (Element.onIndividualClick openMsg :: headerAttrs False)
-        [ headerText renderConfig False label
-        , headerSorting renderConfig False sorting
-        , Icon.filter label
-            |> Icon.withSize contextSize
-            |> Icon.withColor (headerColor False)
-            |> Icon.renderElement renderConfig
-            |> Element.el [ Element.alignRight ]
-        ]
+    Icon.filter label
+        |> Icon.withSize contextSize
+        |> Icon.withColor (headerColor False)
+        |> Icon.renderElement renderConfig
+        |> Element.el [ Element.alignRight ]
+        |> headerBox renderConfig openMsg label sorting False
 
 
 headerApplied : RenderConfig -> msg -> msg -> String -> String -> Sorters.ColumnStatus -> Element msg
 headerApplied renderConfig openMsg clearMsg clearHint label sorting =
     -- Button.primary
-    Element.row (Element.onIndividualClick openMsg :: headerAttrs True)
-        [ headerText renderConfig True label
-        , headerSorting renderConfig True sorting
-        , Button.fromIcon (Icon.close clearHint)
-            |> Button.cmd clearMsg Button.primary
-            |> Button.withSize contextSize
-            |> Button.renderElement renderConfig
-            |> Element.el [ Element.alignRight ]
-        ]
+    Button.fromIcon (Icon.close clearHint)
+        |> Button.cmd clearMsg Button.primary
+        |> Button.withSize contextSize
+        |> Button.renderElement renderConfig
+        |> Element.el [ Element.alignRight ]
+        |> headerBox renderConfig openMsg label sorting True
 
 
 headerText : RenderConfig -> Bool -> String -> Element msg
@@ -149,11 +143,23 @@ headerText renderConfig isApplied label =
     label
         |> Text.ellipsizedText renderConfig Text.SizeCaption
         |> Element.el
-            (Font.size textSize
-                :: Font.semiBold
-                :: Font.color (Palette.toElementColor <| headerColor isApplied)
-                :: shrinkButClip
-            )
+            [ Font.size textSize
+            , Font.semiBold
+            , Font.color (Palette.toElementColor <| headerColor isApplied)
+            , Element.centerY
+            ]
+
+
+headerBox : RenderConfig -> msg -> String -> Sorters.ColumnStatus -> Bool -> Element msg -> Element msg
+headerBox renderConfig openMsg label sorting isFilterApplied rightIcon =
+    Element.row (Element.onIndividualClick openMsg :: headerAttrs isFilterApplied)
+        [ Element.row shrinkButClip
+            [ headerText renderConfig isFilterApplied label
+            , headerSorting renderConfig isFilterApplied sorting
+            ]
+            |> Element.el [ Element.width fill, Element.clip ]
+        , rightIcon
+        ]
 
 
 headerColor : Bool -> Palette.Color

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -368,6 +368,8 @@ sortAs renderConfig config direction =
             |> Text.withColor (Palette.color tonePrimary brightnessMiddle)
             |> Text.renderElement renderConfig
         , icon content
+            |> Icon.withColor (Palette.color tonePrimary brightnessMiddle)
+            |> Icon.withSize Size.extraSmall
             |> Icon.renderElement renderConfig
         ]
 

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -6,7 +6,6 @@ module UI.Internal.Tables.Sorters exposing
     , SortingDirection(..)
     , get
     , itemsApplySorting
-    , notSorting
     , sortBy
     , sortDecreasing
     , sortIncreasing
@@ -49,20 +48,10 @@ type alias ColumnStatus =
 
 
 update : Msg -> Sorters item columns -> ( Sorters item columns, Cmd msg )
-update msg ((Sorters sorters) as sorters_) =
+update msg sorters =
     case msg of
         SetSorting index direction ->
-            case NArray.get index sorters.columns of
-                Just (Sortable by) ->
-                    ( Sorters
-                        { sorters
-                            | status = Just { column = index, by = by, direction = direction }
-                        }
-                    , Cmd.none
-                    )
-
-                _ ->
-                    ( sorters_, Cmd.none )
+            ( sort direction index sorters, Cmd.none )
 
 
 itemsApplySorting : Sorters item columns -> List item -> List item
@@ -140,11 +129,6 @@ sort direction column ((Sorters accu) as sorters) =
 
         Nothing ->
             sorters
-
-
-notSorting : Sorters item columns -> Sorters item columns
-notSorting (Sorters sorters) =
-    Sorters { sorters | status = Nothing }
 
 
 get : Int -> Sorters item columns -> ColumnStatus

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -1,8 +1,10 @@
 module UI.Internal.Tables.Sorters exposing
-    ( Msg
+    ( ColumnStatus
+    , Msg(..)
     , Sorter(..)
     , Sorters
     , SortingDirection(..)
+    , get
     , itemsApplySorting
     , notSorting
     , sortBy
@@ -13,6 +15,7 @@ module UI.Internal.Tables.Sorters exposing
     , update
     )
 
+import UI.Internal.Basics exposing (flip)
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Utils.TypeNumbers as T
 
@@ -40,6 +43,10 @@ type Sorters item columns
         { columns : NArray (Sorter item) columns
         , status : Maybe (SortingStatus item)
         }
+
+
+type alias ColumnStatus =
+    Maybe (Maybe SortingDirection)
 
 
 update : Msg -> Sorters item columns -> ( Sorters item columns, Cmd msg )
@@ -127,3 +134,26 @@ sort direction column ((Sorters accu) as sorters) =
 notSorting : Sorters item columns -> Sorters item columns
 notSorting (Sorters sorters) =
     Sorters { sorters | status = Nothing }
+
+
+get : Int -> Sorters item columns -> ColumnStatus
+get index (Sorters { columns, status }) =
+    let
+        getDirection currentSorting =
+            if currentSorting.column == index then
+                Just currentSorting.direction
+
+            else
+                Nothing
+
+        isSortableThen sortable =
+            case sortable of
+                Sortable _ ->
+                    Just (Maybe.andThen getDirection status)
+
+                Unsortable ->
+                    Nothing
+    in
+    Maybe.andThen
+        isSortableThen
+        (NArray.get index columns)

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -1,58 +1,130 @@
-module UI.Internal.Tables.Sorters exposing (Sorter(..), Sorters, SortingStatus(..), notSorting, sortBy, sortDecreasing, sortIncreasing, unsortable)
+module UI.Internal.Tables.Sorters exposing
+    ( Msg
+    , Sorter(..)
+    , Sorters
+    , SortingDirection(..)
+    , itemsApplySorting
+    , notSorting
+    , sortBy
+    , sortDecreasing
+    , sortIncreasing
+    , sortersEmpty
+    , unsortable
+    , update
+    )
 
 import UI.Internal.Basics exposing (flip, maybeNotThen)
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Utils.TypeNumbers as T
 
 
+type Msg
+    = ToDo
+
+
 type Sorter item
-    = Sortable
-        { sortBy : item -> String
-        , status : SortingStatus
-        }
+    = Sortable (item -> String)
     | Unsortable
 
 
-type SortingStatus
-    = NotSorting
-    | SortIncreasing
+type SortingDirection
+    = SortIncreasing
     | SortDecreasing
 
 
-type alias Sorters item columns =
-    { columns : NArray (Filter item) columns
-    , activeColumn : Maybe { activeIndex : Int, cachedIndex : List String }
-    }
+type alias SortingStatus item =
+    { column : Int, by : item -> String, direction : SortingDirection }
 
 
+type Sorters item columns
+    = Sorters
+        { columns : NArray (Sorter item) columns
+        , status : Maybe (SortingStatus item)
+        }
+
+
+update : Msg -> Sorters item columns -> ( Sorters item columns, Cmd msg )
+update _ sorters =
+    ( sorters, Cmd.none )
+
+
+itemsApplySorting : Sorters item columns -> List item -> List item
+itemsApplySorting (Sorters sorters) items =
+    case sorters.status of
+        Nothing ->
+            items
+
+        Just status ->
+            let
+                sortedItems =
+                    List.sortBy status.by items
+            in
+            case status.direction of
+                SortIncreasing ->
+                    sortedItems
+
+                SortDecreasing ->
+                    List.reverse sortedItems
+
+
+sortersEmpty : Sorters item T.Zero
 sortersEmpty =
-    ()
+    Sorters
+        { columns = NArray.empty
+        , status = Nothing
+        }
 
 
 sortBy :
     (item -> String)
-    -> SortingStatus
     -> Sorters item columns
     -> Sorters item (T.Increase columns)
-sortBy fn status =
-    { sortBy = sortBy
-    , status = status
-    }
-        |> Sortable
-        |> flip NArray.push accu
+sortBy fn (Sorters accu) =
+    Sorters
+        { columns = NArray.push (Sortable fn) accu.columns
+        , status = accu.status
+        }
 
 
-unsortable =
-    ()
+unsortable : Sorters item columns -> Sorters item (T.Increase columns)
+unsortable (Sorters accu) =
+    Sorters
+        { columns = NArray.push Unsortable accu.columns
+        , status = accu.status
+        }
 
 
+sortIncreasing : Int -> Sorters item columns -> Sorters item columns
 sortIncreasing =
-    ()
+    sort SortIncreasing
 
 
+sortDecreasing : Int -> Sorters item columns -> Sorters item columns
 sortDecreasing =
-    ()
+    sort SortDecreasing
 
 
-notSorting =
-    ()
+sort : SortingDirection -> Int -> Sorters item columns -> Sorters item columns
+sort direction column ((Sorters accu) as sorters) =
+    case NArray.get column accu.columns of
+        Just (Sortable by) ->
+            Sorters
+                { accu
+                    | status =
+                        Just
+                            { column = column
+                            , by = by
+                            , direction = direction
+                            }
+                }
+
+        Just Unsortable ->
+            sorters
+
+        Nothing ->
+            sorters
+
+
+notSorting : Sorters item columns -> Sorters item columns
+notSorting (Sorters sorters) =
+    Sorters { sorters | status = Nothing }

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -20,6 +20,7 @@ import UI.Utils.TypeNumbers as T
 
 type Msg
     = SetSorting Int SortingDirection
+    | ClearSorting
 
 
 type Sorter item
@@ -52,6 +53,14 @@ update msg sorters =
     case msg of
         SetSorting index direction ->
             ( sort direction index sorters, Cmd.none )
+
+        ClearSorting ->
+            ( clear sorters, Cmd.none )
+
+
+clear : Sorters item columns -> Sorters item columns
+clear (Sorters sorters) =
+    Sorters { sorters | status = Nothing }
 
 
 itemsApplySorting : Sorters item columns -> List item -> List item

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -13,7 +13,6 @@ module UI.Internal.Tables.Sorters exposing
     , update
     )
 
-import UI.Internal.Basics exposing (flip, maybeNotThen)
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Utils.TypeNumbers as T
 

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -1,0 +1,58 @@
+module UI.Internal.Tables.Sorters exposing (Sorter(..), Sorters, SortingStatus(..), notSorting, sortBy, sortDecreasing, sortIncreasing, unsortable)
+
+import UI.Internal.Basics exposing (flip, maybeNotThen)
+import UI.Internal.NArray as NArray exposing (NArray)
+import UI.Utils.TypeNumbers as T
+
+
+type Sorter item
+    = Sortable
+        { sortBy : item -> String
+        , status : SortingStatus
+        }
+    | Unsortable
+
+
+type SortingStatus
+    = NotSorting
+    | SortIncreasing
+    | SortDecreasing
+
+
+type alias Sorters item columns =
+    { columns : NArray (Filter item) columns
+    , activeColumn : Maybe { activeIndex : Int, cachedIndex : List String }
+    }
+
+
+sortersEmpty =
+    ()
+
+
+sortBy :
+    (item -> String)
+    -> SortingStatus
+    -> Sorters item columns
+    -> Sorters item (T.Increase columns)
+sortBy fn status =
+    { sortBy = sortBy
+    , status = status
+    }
+        |> Sortable
+        |> flip NArray.push accu
+
+
+unsortable =
+    ()
+
+
+sortIncreasing =
+    ()
+
+
+sortDecreasing =
+    ()
+
+
+notSorting =
+    ()

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -15,13 +15,12 @@ module UI.Internal.Tables.Sorters exposing
     , update
     )
 
-import UI.Internal.Basics exposing (flip)
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Utils.TypeNumbers as T
 
 
 type Msg
-    = ToDo
+    = SetSorting Int SortingDirection
 
 
 type Sorter item
@@ -50,8 +49,20 @@ type alias ColumnStatus =
 
 
 update : Msg -> Sorters item columns -> ( Sorters item columns, Cmd msg )
-update _ sorters =
-    ( sorters, Cmd.none )
+update msg ((Sorters sorters) as sorters_) =
+    case msg of
+        SetSorting index direction ->
+            case NArray.get index sorters.columns of
+                Just (Sortable by) ->
+                    ( Sorters
+                        { sorters
+                            | status = Just { column = index, by = by, direction = direction }
+                        }
+                    , Cmd.none
+                    )
+
+                _ ->
+                    ( sorters_, Cmd.none )
 
 
 itemsApplySorting : Sorters item columns -> List item -> List item

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -4,6 +4,7 @@ module UI.Internal.Utils.Element exposing
     , overflowAttrs
     , overflowVisible
     , overlay
+    , shrinkButClip
     , style
     , title
     , tuplesToStyles
@@ -78,6 +79,13 @@ overlay closeMsg content =
         , Element.inFront content
         ]
         (overlayBackground closeMsg)
+
+
+shrinkButClip : List (Attribute msg)
+shrinkButClip =
+    [ Element.htmlAttribute <| HtmlAttrs.style "width" "min-content"
+    , Element.htmlAttribute <| HtmlAttrs.style "max-width" "100%"
+    ]
 
 
 

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -83,9 +83,11 @@ overlay closeMsg content =
 
 shrinkButClip : List (Attribute msg)
 shrinkButClip =
-    [ Element.htmlAttribute <| HtmlAttrs.style "width" "min-content"
-    , Element.htmlAttribute <| HtmlAttrs.style "max-width" "100%"
-    ]
+    List.map tuplesToStyles
+        [ ( "width", "min-content" )
+        , ( "max-width", "100%" )
+        , ( "overflow", "clip" )
+        ]
 
 
 

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -378,11 +378,24 @@ updateFilters state subMsg =
             filters
                 |> Filters.update subMsg
                 |> (\( newFilters, subCmd ) ->
-                        ( State { state | filters = Just newFilters }, subCmd )
+                        ( applyFilters newFilters state, subCmd )
                    )
 
         Nothing ->
             ( State state, Cmd.none )
+
+
+applyFilters newFilters state =
+    State
+        { state
+            | visibleItems =
+                newFilters
+                    |> NArray.toList
+                    |> List.filterMap Filters.filterGet
+                    |> List.foldl Filters.filtersReduce (always True)
+                    |> flip List.filter state.items
+            , filters = Just newFilters
+        }
 
 
 updateSelectionToggleAll : StateModel msg item columns -> ( State msg item columns, Cmd msg )

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -49,7 +49,10 @@ Where `Book` is:
             |> column "Author" (columnWidthPixels 240)
             |> column "Year" (columnWidthPixels 120)
 
-    toTableRow { author, title, year } =
+    toTableRow =
+        { toKey = .title, toTableRowView}
+
+    toTableRowView { author, title, year } =
         rowEmpty
             |> rowCellText (Text.body1 title)
             |> rowCellText (Text.body2 author)
@@ -77,7 +80,7 @@ And on model:
     }
 
     { -...
-    , tableState = Stateful.withFilters Book.someFilters Stateful.init
+    , tableState = Stateful.stateWithFilters Book.someFilters Stateful.init
     }
 
 

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -1372,7 +1372,7 @@ selectionCell : RenderConfig -> Selection item -> item -> ( String, Element (Msg
 selectionCell renderConfig selection item =
     item
         |> internalIsSelected selection
-        |> checkbox "Select row" (SelectionSet item)
+        |> checkbox (localeTerms renderConfig |> .tables |> .selectRow) (SelectionSet item)
         |> Checkbox.withLabelVisible False
         |> Checkbox.renderElement renderConfig
         |> Element.el

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -11,7 +11,7 @@ module UI.Tables.Stateful exposing
     , localSelectFilter, remoteSelectFilter
     , Sorters, stateWithSorters
     , sortersEmpty, sortBy, unsortable
-    , notSorting, sortDecreasing, sortIncreasing
+    , sortDecreasing, sortIncreasing
     , withWidth
     , stateWithSelection, stateIsSelected
     , renderElement
@@ -141,7 +141,7 @@ And on model:
 
 @docs Sorters, stateWithSorters
 @docs sortersEmpty, sortBy, unsortable
-@docs notSorting, sortDecreasing, sortIncreasing
+@docs sortDecreasing, sortIncreasing
 
 
 # Width
@@ -1020,10 +1020,22 @@ withWidth width (Table prop opt_) =
 -- Sorting
 
 
+{-| Array with all the columns' sorting definitions.
+
+This is a type-safe sized-array.
+See [`TypeNumbers`](UI-Utils-TypeNumbers) for how to compose its phantom type.
+
+-}
 type alias Sorters item columns =
     Sorters.Sorters item columns
 
 
+{-| Apply sortings defintion to a table's [`State`](#State).
+
+    model =
+        stateWithSorters Book.sortersInit init
+
+-}
 stateWithSorters : Sorters item columns -> State msg item columns -> State msg item columns
 stateWithSorters sorters (State state) =
     State
@@ -1034,11 +1046,6 @@ stateWithSorters sorters (State state) =
                     |> maybeThen Filters.itemsApplyFilters state.filters
                     |> Sorters.itemsApplySorting sorters
         }
-
-
-notSorting : Sorters item columns -> Sorters item columns
-notSorting =
-    Sorters.notSorting
 
 
 sortBy :

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -335,6 +335,18 @@ init =
         }
 
 
+{-| Each of these items will become a row in this table.
+
+    stateWithItems
+        [ Book "Dan Brown" "Angels & Demons" "2000"
+        , Book "Dan Brown" "The Da Vinci Code" "2003"
+        , Book "Dan Brown" "The Lost Symbol" "2009"
+        , Book "Dan Brown" "Inferno" "2013"
+        , Book "Dan Brown" "Origin" "2017"
+        ]
+        someTableState
+
+-}
 stateWithItems : List item -> State msg item columns -> State msg item columns
 stateWithItems items (State state) =
     State
@@ -1048,6 +1060,15 @@ stateWithSorters sorters (State state) =
         }
 
 
+{-| Describes how to convert a column's value to a sortable `List String`.
+
+    sortersInit =
+        sortersEmpty
+            |> sortBy .title
+            |> sortBy .author
+            |> unsortable
+
+-}
 sortBy :
     (item -> String)
     -> Sorters item columns
@@ -1056,21 +1077,55 @@ sortBy =
     Sorters.sortBy
 
 
+{-| Changes the initial sorting to some columns as descreasing.
+
+    model =
+        stateWithSorters
+            (Book.sortersInit |> sortDecreasing 1)
+            init
+
+-}
 sortDecreasing : Int -> Sorters item columns -> Sorters item columns
 sortDecreasing =
     Sorters.sortDecreasing
 
 
+{-| Changes the initial sorting to some columns as increasing.
+
+    model =
+        stateWithSorters
+            (Book.sortersInit |> sortIncreasing 1)
+            init
+
+-}
 sortIncreasing : Int -> Sorters item columns -> Sorters item columns
 sortIncreasing =
     Sorters.sortIncreasing
 
 
+{-| An empty [`Sorters`](#Sorters) set.
+
+    sortersInit =
+        sortersEmpty
+            |> sortBy .title
+            |> sortBy .author
+            |> unsortable
+
+-}
 sortersEmpty : Sorters item T.Zero
 sortersEmpty =
     Sorters.sortersEmpty
 
 
+{-| Describes that some column is not sortable.
+
+    sortersInit =
+        sortersEmpty
+            |> sortBy .title
+            |> sortBy .author
+            |> unsortable
+
+-}
 unsortable : Sorters item columns -> Sorters item (T.Increase columns)
 unsortable =
     Sorters.unsortable

--- a/yarn.lock
+++ b/yarn.lock
@@ -5590,9 +5590,10 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-paack-ui-assets@PaackEng/paack-ui-assets#0.1.0:
+paack-ui-assets@^0.1.0:
   version "0.1.0"
-  resolved "https://codeload.github.com/PaackEng/paack-ui-assets/tar.gz/2bdc8837d3cc6f5d0e7aa7d8203cc5e2e53d9685"
+  resolved "https://registry.yarnpkg.com/paack-ui-assets/-/paack-ui-assets-0.1.0.tgz#3efbd3a86a854f0e86c5ffe450ea21eef2273cf7"
+  integrity sha512-auag6q6bTZmwHkk9JyBejLIThVOyGqzY6cyFt9LCqI6O01hCrRF538+0Himd16wfyPPcvjP+B2iL/V/WVfajzg==
 
 package-json@^6.3.0:
   version "6.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4145,9 +4145,10 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-i18n-json-to-elm@PedroHLC/i18n-json-to-elm:
-  version "1.1.1"
-  resolved "https://codeload.github.com/PedroHLC/i18n-json-to-elm/tar.gz/b50364908fdf02538d4729e39168fcc3fce2fd76"
+i18n-json-to-elm@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/i18n-json-to-elm/-/i18n-json-to-elm-1.1.2.tgz#acdfa3b090f670d7267fd2b71ba55f60257b0cf7"
+  integrity sha512-saKBocPnwDBk32KxSxyPChtGaEOkyBoKewGLi2/sA6TGkQ+s5mc/Cv+uEx2zhQ0M+8toVV89rFTIY58YBro+Zw==
   dependencies:
     elm-format "^0.8.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5590,10 +5590,9 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-paack-ui-assets@^0.0.13:
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/paack-ui-assets/-/paack-ui-assets-0.0.13.tgz#687b7d8f65231ad67b0505e42fd85475eecfb210"
-  integrity sha512-/zPuKYhrDqSeuVrj4cwCyNSLtgEUc05QtSA8a0xQowBLYbksvfqyWgZeZfgVP68Dx8aJ59BmJclXId2YhhAqVQ==
+paack-ui-assets@PaackEng/paack-ui-assets#0.1.0:
+  version "0.1.0"
+  resolved "https://codeload.github.com/PaackEng/paack-ui-assets/tar.gz/2bdc8837d3cc6f5d0e7aa7d8203cc5e2e53d9685"
 
 package-json@^6.3.0:
   version "6.5.0"


### PR DESCRIPTION
#### :thinking: What?

* Allows `Tables.Stateful` to have per-column sorting;
* Add `stateWithItems` and `stateWithSorters`, while caching filtered+sorted items in state;
* Update translations;
* Update paack-ui-assets (Including Icons);
* Add config so editors will keep POEditor formatting in i18n's JSONs.

#### :man_shrugging: Why?

> As column headers are common UI elements this change have an impact on DS. Let’s propose a header component that allows different actions to modify the table, like order and filter. -- Marchese, Juan

#### :pushpin: Jira Issue

[WMS-652](https://paacklogistics.atlassian.net/browse/WMS-652) and [DES-29](https://paacklogistics.atlassian.net/browse/DES-29)


#### :no_good: Blocked by

Not blocked anymore.

#### :clipboard: Pending

- [x] French translations for the sorting terms