### PR TITLE
Sidebar Hotfix

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "exposed-modules": [
         "UI.Alert",
         "UI.Badge",

--- a/showcase/src/Sidebar/Stories.elm
+++ b/showcase/src/Sidebar/Stories.elm
@@ -82,7 +82,8 @@ nonPersistentView renderConfig model =
 page : Element Msg
 page =
     storyBorder <|
-        Element.el [ width (px 800), height (px 600) ] Element.none
+        Element.el [ width (px 800), height (px 600) ]
+            (Element.text "Example content")
 
 
 menu : Model -> Menu.Menu Msg

--- a/src/UI/Internal/Menu.elm
+++ b/src/UI/Internal/Menu.elm
@@ -6,6 +6,7 @@ module UI.Internal.Menu exposing
     , Page
     , Properties
     , default
+    , toggleExpanded
     )
 
 import Element exposing (Element)
@@ -57,3 +58,8 @@ default toggle isExpanded =
         , actions = []
         , logo = Nothing
         }
+
+
+toggleExpanded : Bool -> Menu msg -> Menu msg
+toggleExpanded expanded (Menu props options) =
+    Menu { props | isExpanded = expanded } options

--- a/src/UI/NavigationContainer.elm
+++ b/src/UI/NavigationContainer.elm
@@ -297,7 +297,11 @@ appearance/behavior of the sidebar when it is enabled by the `hasMenu` flag.
 -}
 withSidebarStyle : SidebarStyle -> Navigator page msg -> Navigator page msg
 withSidebarStyle style (Navigator nav) =
-    Navigator { nav | sidebarStyle = style }
+    Navigator
+        { nav
+            | sidebarStyle = style
+            , menu = Menu.toggleExpanded False nav.menu
+        }
 
 
 {-| Persistent style of the sidebar. It occupies more space when open pushing

--- a/src/UI/Utils/Element.elm
+++ b/src/UI/Utils/Element.elm
@@ -180,7 +180,7 @@ fadeOut : Transition msg
 fadeOut =
     { transition = "opacity .2s"
     , on = [ Element.alpha 0.5 ]
-    , off = [ Element.alpha 0 ]
+    , off = [ Element.alpha 0, tuplesToStyles ( "pointer-events", "none" ) ]
     }
 
 


### PR DESCRIPTION
#### :thinking: What?
Smol hack to force the sidebar to start closed when non-persistent
Fix the sidebar overlay that was preventing clicks on the content


#### :man_shrugging: Why?
Because these are the two issues I found testing the sidebar in a real app with the `NavigationContainer`
