### PR TITLE
Test | Turn on shadowDOM in Cypress

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "http://localhost:1234"
+  "baseUrl": "http://localhost:1234",
+  "includeShadowDom": true
 }


### PR DESCRIPTION
#### :thinking: What?

Trying to change one setting in `cypress.json`


#### :man_shrugging: Why?

To see tooltiped text in our CI.
I was reading [Cypress's configuration docs](https://docs.cypress.io/guides/references/configuration.html#Global) and came across it.


#### :pushpin: Jira Issue

Not tracked.


#### :no_good: Blocked by

Not blocked.


#### :clipboard: Pending

Nothing