### PR TITLE
Port Stateful table from Cmd to Effects

### DIFF
--- a/showcase/src/Tables/Stories.elm
+++ b/showcase/src/Tables/Stories.elm
@@ -6,6 +6,7 @@ import Return exposing (Return)
 import Tables.Book as Book exposing (Book)
 import Tables.Model as Stories
 import Tables.Msg as Stories
+import UI.Effect as Effect
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
 import UI.Tables.Common as Tables
 import UI.Tables.Stateful as Stateful
@@ -29,11 +30,13 @@ update msg ({ mainTableState, selecTableState } as model) =
             mainTableState
                 |> Stateful.update subMsg
                 |> Tuple.mapFirst (\s -> { model | mainTableState = s })
+                |> Tuple.mapSecond Effect.perform
 
         Stories.ForSelectable subMsg ->
             selecTableState
                 |> Stateful.update subMsg
                 |> Tuple.mapFirst (\s -> { model | selecTableState = s })
+                |> Tuple.mapSecond Effect.perform
 
 
 stories : RenderConfig -> ExplorerUI

--- a/src/UI/Effect.elm
+++ b/src/UI/Effect.elm
@@ -1,0 +1,18 @@
+module UI.Effect exposing (Effect(..), perform)
+
+import Task
+
+
+type Effect msg
+    = MsgToCmd msg
+    | None
+
+
+perform : Effect msg -> Cmd msg
+perform effect =
+    case effect of
+        MsgToCmd msg ->
+            Task.perform identity <| Task.succeed msg
+
+        None ->
+            Cmd.none

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -48,14 +48,14 @@ type alias ColumnStatus =
     Maybe (Maybe SortingDirection)
 
 
-update : Msg -> Sorters item columns -> ( Sorters item columns, Cmd msg )
+update : Msg -> Sorters item columns -> Sorters item columns
 update msg sorters =
     case msg of
         SetSorting index direction ->
-            ( sort direction index sorters, Cmd.none )
+            sort direction index sorters
 
         ClearSorting ->
-            ( clear sorters, Cmd.none )
+            clear sorters
 
 
 clear : Sorters item columns -> Sorters item columns


### PR DESCRIPTION
#### :thinking: What?

Replace `Cmd` with `Effect` in `Stateful` table.

#### :man_shrugging: Why?

- Support to `elm-program-test`.
- Possible to intercept these effects in tests from other applications like `wms-web`.

### :fire: Extra

This is a prequel to adding analytics support to `paack-ui` (analytics events are planned to be an effect tag).

To keep things simple, the `Effect` type here is not a list yet, but it may turn into one someday if required.