### PR TITLE
WMS-794 | Table Analytics

### DIFF
--- a/src/UI/Analytics.elm
+++ b/src/UI/Analytics.elm
@@ -14,44 +14,45 @@ type TableAnalytics
     | ClearSorting
 
 
-encode : Analytics -> Value
+type alias Property =
+    ( String, Value )
+
+
+encode : Analytics -> List Property
 encode analytics =
     case analytics of
         TableAnalytics a ->
             encodeTable a
 
 
-encodeAction : String -> ( String, Value )
+encodeAction : String -> Property
 encodeAction name =
     ( "action", Encode.string name )
 
 
-encodeColumn : Int -> ( String, Value )
+encodeColumn : Int -> Property
 encodeColumn column =
     ( "column", Encode.int column )
 
 
-encodeTable : TableAnalytics -> Value
+encodeTable : TableAnalytics -> List Property
 encodeTable analytics =
     case analytics of
         ApplyFilter column ->
-            Encode.object
-                [ encodeAction "apply_filter"
-                , encodeColumn column
-                ]
+            [ encodeAction "apply_filter"
+            , encodeColumn column
+            ]
 
         ClearFilter column ->
-            Encode.object
-                [ encodeAction "clear_filter"
-                , encodeColumn column
-                ]
+            [ encodeAction "clear_filter"
+            , encodeColumn column
+            ]
 
         SetSorting column reverse ->
-            Encode.object
-                [ encodeAction "set_sorting"
-                , encodeColumn column
-                , ( "reverse", Encode.bool reverse )
-                ]
+            [ encodeAction "set_sorting"
+            , encodeColumn column
+            , ( "reverse", Encode.bool reverse )
+            ]
 
         ClearSorting ->
-            Encode.object [ encodeAction "clear_sorting" ]
+            [ encodeAction "clear_sorting" ]

--- a/src/UI/Analytics.elm
+++ b/src/UI/Analytics.elm
@@ -1,58 +1,16 @@
-module UI.Analytics exposing (Analytics(..), TableAnalytics(..), encode)
+module UI.Analytics exposing (Analytics, Property, encode)
 
-import Json.Encode as Encode exposing (Value)
-
-
-type Analytics
-    = TableAnalytics TableAnalytics
+import UI.Internal.Analytics as Internal
 
 
-type TableAnalytics
-    = ApplyFilter Int
-    | ClearFilter Int
-    | SetSorting Int Bool
-    | ClearSorting
+type alias Analytics =
+    Internal.Analytics
 
 
 type alias Property =
-    ( String, Value )
+    Internal.Property
 
 
 encode : Analytics -> List Property
-encode analytics =
-    case analytics of
-        TableAnalytics a ->
-            encodeTable a
-
-
-encodeAction : String -> Property
-encodeAction name =
-    ( "action", Encode.string name )
-
-
-encodeColumn : Int -> Property
-encodeColumn column =
-    ( "column", Encode.int column )
-
-
-encodeTable : TableAnalytics -> List Property
-encodeTable analytics =
-    case analytics of
-        ApplyFilter column ->
-            [ encodeAction "apply_filter"
-            , encodeColumn column
-            ]
-
-        ClearFilter column ->
-            [ encodeAction "clear_filter"
-            , encodeColumn column
-            ]
-
-        SetSorting column reverse ->
-            [ encodeAction "set_sorting"
-            , encodeColumn column
-            , ( "reverse", Encode.bool reverse )
-            ]
-
-        ClearSorting ->
-            [ encodeAction "clear_sorting" ]
+encode =
+    Internal.encode

--- a/src/UI/Analytics.elm
+++ b/src/UI/Analytics.elm
@@ -1,0 +1,57 @@
+module UI.Analytics exposing (Analytics(..), TableAnalytics(..), encode)
+
+import Json.Encode as Encode exposing (Value)
+
+
+type Analytics
+    = TableAnalytics TableAnalytics
+
+
+type TableAnalytics
+    = ApplyFilter Int
+    | ClearFilter Int
+    | SetSorting Int Bool
+    | ClearSorting
+
+
+encode : Analytics -> Value
+encode analytics =
+    case analytics of
+        TableAnalytics a ->
+            encodeTable a
+
+
+encodeAction : String -> ( String, Value )
+encodeAction name =
+    ( "action", Encode.string name )
+
+
+encodeColumn : Int -> ( String, Value )
+encodeColumn column =
+    ( "column", Encode.int column )
+
+
+encodeTable : TableAnalytics -> Value
+encodeTable analytics =
+    case analytics of
+        ApplyFilter column ->
+            Encode.object
+                [ encodeAction "apply_filter"
+                , encodeColumn column
+                ]
+
+        ClearFilter column ->
+            Encode.object
+                [ encodeAction "clear_filter"
+                , encodeColumn column
+                ]
+
+        SetSorting column reverse ->
+            Encode.object
+                [ encodeAction "set_sorting"
+                , encodeColumn column
+                , ( "reverse", Encode.bool reverse )
+                ]
+
+        ClearSorting ->
+            Encode.object [ encodeAction "clear_sorting" ]

--- a/src/UI/Effect.elm
+++ b/src/UI/Effect.elm
@@ -3,6 +3,7 @@ module UI.Effect exposing
     , SideEffect(..)
     , analytics
     , batch
+    , map
     , msgToCmd
     , none
     , perform
@@ -29,6 +30,20 @@ none =
 batch : List (Effect msg) -> Effect msg
 batch =
     List.concat
+
+
+map : (a -> b) -> Effect a -> Effect b
+map =
+    let
+        mapSideEffect f e =
+            case e of
+                MsgToCmd msg ->
+                    MsgToCmd (f msg)
+
+                Analytics data ->
+                    Analytics data
+    in
+    mapSideEffect >> List.map
 
 
 msgToCmd : msg -> Effect msg

--- a/src/UI/Effect.elm
+++ b/src/UI/Effect.elm
@@ -1,18 +1,58 @@
-module UI.Effect exposing (Effect(..), perform)
+module UI.Effect exposing
+    ( Effect
+    , SideEffect(..)
+    , analytics
+    , batch
+    , msgToCmd
+    , none
+    , perform
+    )
 
 import Task
+import UI.Analytics exposing (Analytics)
 
 
-type Effect msg
+type alias Effect msg =
+    List (SideEffect msg)
+
+
+type SideEffect msg
     = MsgToCmd msg
-    | None
+    | Analytics Analytics
+
+
+none : Effect msg
+none =
+    []
+
+
+batch : List (Effect msg) -> Effect msg
+batch =
+    List.concat
+
+
+msgToCmd : msg -> Effect msg
+msgToCmd msg =
+    [ MsgToCmd msg ]
+
+
+analytics : Analytics -> Effect msg
+analytics analytics_ =
+    [ Analytics analytics_ ]
 
 
 perform : Effect msg -> Cmd msg
 perform effect =
+    effect
+        |> List.map performSideEffect
+        |> Cmd.batch
+
+
+performSideEffect : SideEffect msg -> Cmd msg
+performSideEffect effect =
     case effect of
         MsgToCmd msg ->
             Task.perform identity <| Task.succeed msg
 
-        None ->
+        Analytics _ ->
             Cmd.none

--- a/src/UI/Internal/Analytics.elm
+++ b/src/UI/Internal/Analytics.elm
@@ -1,0 +1,58 @@
+module UI.Internal.Analytics exposing (Analytics(..), Property, TableAnalytics(..), encode)
+
+import Json.Encode as Encode exposing (Value)
+
+
+type Analytics
+    = TableAnalytics TableAnalytics
+
+
+type TableAnalytics
+    = ApplyFilter Int
+    | ClearFilter Int
+    | SetSorting Int Bool
+    | ClearSorting
+
+
+type alias Property =
+    ( String, Value )
+
+
+encode : Analytics -> List Property
+encode analytics =
+    case analytics of
+        TableAnalytics a ->
+            encodeTable a
+
+
+encodeAction : String -> Property
+encodeAction name =
+    ( "action", Encode.string name )
+
+
+encodeColumn : Int -> Property
+encodeColumn column =
+    ( "column", Encode.int column )
+
+
+encodeTable : TableAnalytics -> List Property
+encodeTable analytics =
+    case analytics of
+        ApplyFilter column ->
+            [ encodeAction "apply_filter"
+            , encodeColumn column
+            ]
+
+        ClearFilter column ->
+            [ encodeAction "clear_filter"
+            , encodeColumn column
+            ]
+
+        SetSorting column reverse ->
+            [ encodeAction "set_sorting"
+            , encodeColumn column
+            , ( "reverse", Encode.bool reverse )
+            ]
+
+        ClearSorting ->
+            [ encodeAction "clear_sorting" ]

--- a/src/UI/Internal/Tables/Filters.elm
+++ b/src/UI/Internal/Tables/Filters.elm
@@ -37,8 +37,8 @@ module UI.Internal.Tables.Filters exposing
 
 import Array exposing (Array)
 import Time exposing (Posix)
-import UI.Analytics as Analytics
 import UI.Effect as Effect exposing (Effect)
+import UI.Internal.Analytics as Analytics
 import UI.Internal.Basics exposing (flip, maybeNotThen)
 import UI.Internal.DateInput as DateInput exposing (DateInput(..), PeriodComparison(..), PeriodDate, RangeDate)
 import UI.Internal.NArray as NArray exposing (NArray)

--- a/src/UI/Internal/Tables/Filters.elm
+++ b/src/UI/Internal/Tables/Filters.elm
@@ -664,28 +664,28 @@ update : Msg -> Filters msg item columns -> ( Filters msg item columns, Effect m
 update msg model =
     case msg of
         EditSingleText { column, value } ->
-            ( singleTextEdit column value model, Effect.None )
+            ( singleTextEdit column value model, Effect.none )
 
         EditMultiText { column, field, value } ->
-            ( multiTextEdit column field value model, Effect.None )
+            ( multiTextEdit column field value model, Effect.none )
 
         EditSingleDate { column, value } ->
-            ( singleDateEdit column value model, Effect.None )
+            ( singleDateEdit column value model, Effect.none )
 
         EditRangeFromDate { column, value } ->
-            ( rangeDateFromEdit column value model, Effect.None )
+            ( rangeDateFromEdit column value model, Effect.none )
 
         EditRangeToDate { column, value } ->
-            ( rangeDateToEdit column value model, Effect.None )
+            ( rangeDateToEdit column value model, Effect.none )
 
         EditPeriodDate { column, value } ->
-            ( periodDateEdit column value model, Effect.None )
+            ( periodDateEdit column value model, Effect.none )
 
         EditPeriodComparison { column, value } ->
-            ( periodDateComparisonEdit column value model, Effect.None )
+            ( periodDateComparisonEdit column value model, Effect.none )
 
         EditSelect { column, value } ->
-            ( selectEdit column value model, Effect.None )
+            ( selectEdit column value model, Effect.none )
 
         Apply column ->
             applyFilter column model
@@ -699,12 +699,12 @@ dispatchApply strategy value newModel =
     case strategy of
         Local _ ->
             ( newModel
-            , Effect.None
+            , Effect.none
             )
 
         Remote { applyMsg } ->
             ( newModel
-            , Effect.MsgToCmd <| applyMsg value
+            , Effect.msgToCmd <| applyMsg value
             )
 
 
@@ -713,12 +713,12 @@ dispatchClear strategy newModel =
     case strategy of
         Local _ ->
             ( newModel
-            , Effect.None
+            , Effect.none
             )
 
         Remote { clearMsg } ->
             ( newModel
-            , Effect.MsgToCmd clearMsg
+            , Effect.msgToCmd clearMsg
             )
 
 
@@ -738,7 +738,7 @@ applyShortcut model column config constructor =
                 |> dispatchApply config.strategy newValue
 
         Nothing ->
-            ( model, Effect.None )
+            ( model, Effect.none )
 
 
 applyFilter : Int -> Filters msg item columns -> ( Filters msg item columns, Effect msg )
@@ -763,7 +763,7 @@ applyFilter column model =
             applyShortcut model column config (SelectFilter list)
 
         Nothing ->
-            ( model, Effect.None )
+            ( model, Effect.none )
 
 
 filterClear : Int -> Filters msg item columns -> ( Filters msg item columns, Effect msg )
@@ -812,7 +812,7 @@ filterClear column model =
                 |> dispatchClear config.strategy
 
         Nothing ->
-            ( model, Effect.None )
+            ( model, Effect.none )
 
 
 editableSetCurrent : value -> Editable value -> Editable value

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -14,8 +14,8 @@ module UI.Internal.Tables.Sorters exposing
     , update
     )
 
-import UI.Analytics as Analytics
 import UI.Effect as Effect exposing (Effect)
+import UI.Internal.Analytics as Analytics
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Utils.TypeNumbers as T
 

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -14,6 +14,8 @@ module UI.Internal.Tables.Sorters exposing
     , update
     )
 
+import UI.Analytics as Analytics
+import UI.Effect as Effect exposing (Effect)
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Utils.TypeNumbers as T
 
@@ -48,14 +50,26 @@ type alias ColumnStatus =
     Maybe (Maybe SortingDirection)
 
 
-update : Msg -> Sorters item columns -> Sorters item columns
+update : Msg -> Sorters item columns -> ( Sorters item columns, Effect msg )
 update msg sorters =
     case msg of
         SetSorting index direction ->
-            sort direction index sorters
+            let
+                reverse =
+                    direction == SortDecreasing
+            in
+            ( sort direction index sorters
+            , Analytics.SetSorting index reverse
+                |> Analytics.TableAnalytics
+                |> Effect.analytics
+            )
 
         ClearSorting ->
-            clear sorters
+            ( clear sorters
+            , Analytics.ClearSorting
+                |> Analytics.TableAnalytics
+                |> Effect.analytics
+            )
 
 
 clear : Sorters item columns -> Sorters item columns

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -377,13 +377,13 @@ update msg (State state) =
             updateFilters state subMsg
 
         ForSorters subMsg ->
-            updateSorters state subMsg
+            ( updateSorters state subMsg, Effect.none )
 
         FilterDialogOpen index ->
-            ( State { state | filterDialog = Just index }, Effect.None )
+            ( State { state | filterDialog = Just index }, Effect.none )
 
         FilterDialogClose ->
-            ( State { state | filterDialog = Nothing }, Effect.None )
+            ( State { state | filterDialog = Nothing }, Effect.none )
 
         SelectionToggleAll ->
             updateSelectionToggleAll state
@@ -403,7 +403,7 @@ updateMobileToggle state index =
                 else
                     Just index
         }
-    , Effect.None
+    , Effect.none
     )
 
 
@@ -421,7 +421,7 @@ updateFilters state subMsg =
                    )
 
         Nothing ->
-            ( State state, Effect.None )
+            ( State state, Effect.none )
 
 
 applyFilters : Filters msg item columns -> StateModel msg item columns -> State msg item columns
@@ -436,18 +436,16 @@ applyFilters newFilters state =
         }
 
 
-updateSorters : StateModel msg item columns -> Sorters.Msg -> ( State msg item columns, Effect msg )
+updateSorters : StateModel msg item columns -> Sorters.Msg -> State msg item columns
 updateSorters state subMsg =
     case state.sorters of
         Just sorters ->
-            ( sorters
+            sorters
                 |> Sorters.update subMsg
                 |> flip applySorters state
-            , Effect.None
-            )
 
         Nothing ->
-            ( State state, Effect.None )
+            State state
 
 
 applySorters : Sorters item columns -> StateModel msg item columns -> State msg item columns
@@ -484,7 +482,7 @@ updateSelectionToggleAll state =
             }
     in
     ( State { state | localSelection = Maybe.map invertAll state.localSelection }
-    , Effect.None
+    , Effect.none
     )
 
 
@@ -506,7 +504,7 @@ updateSelectionSet state item value =
             }
     in
     ( State { state | localSelection = Maybe.map setItem state.localSelection }
-    , Effect.None
+    , Effect.none
     )
 
 

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -174,7 +174,7 @@ import Set exposing (Set)
 import Time
 import UI.Checkbox as Checkbox exposing (checkbox)
 import UI.Effect as Effect exposing (Effect)
-import UI.Internal.Basics exposing (flip, ifThenElse, maybeThen, prependMaybe)
+import UI.Internal.Basics exposing (ifThenElse, maybeThen, prependMaybe)
 import UI.Internal.DateInput as DateInput exposing (DateInput, PeriodDate, RangeDate)
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Internal.RenderConfig exposing (localeTerms)
@@ -377,7 +377,7 @@ update msg (State state) =
             updateFilters state subMsg
 
         ForSorters subMsg ->
-            ( updateSorters state subMsg, Effect.none )
+            updateSorters state subMsg
 
         FilterDialogOpen index ->
             ( State { state | filterDialog = Just index }, Effect.none )
@@ -436,16 +436,21 @@ applyFilters newFilters state =
         }
 
 
-updateSorters : StateModel msg item columns -> Sorters.Msg -> State msg item columns
+updateSorters : StateModel msg item columns -> Sorters.Msg -> ( State msg item columns, Effect msg )
 updateSorters state subMsg =
     case state.sorters of
         Just sorters ->
             sorters
                 |> Sorters.update subMsg
-                |> flip applySorters state
+                |> (\( newSorters, subCmd ) ->
+                        ( state
+                            |> applySorters newSorters
+                        , subCmd
+                        )
+                   )
 
         Nothing ->
-            State state
+            ( State state, Effect.none )
 
 
 applySorters : Sorters item columns -> StateModel msg item columns -> State msg item columns


### PR DESCRIPTION
#### :thinking: What?

1. Add some `Analytics` events for table filters and sorters
2.  `Effect` is now a `List (SideEffect msg)` like on `wms-web`

#### :man_shrugging: Why?

1. To provide more analytics events to `wms-web`
2. Because the previous change required firing `Analytics` along with a `MsgToCmd` effect

#### :pushpin: Jira Issue

[WMS-794](https://paacklogistics.atlassian.net/browse/WMS-794)

