### PR TITLE
WMS-801 | Add "empty states" component

### DIFF
--- a/cypress/integration/visual-regression.spec.js
+++ b/cypress/integration/visual-regression.spec.js
@@ -124,6 +124,13 @@ describe('Percy Snapshots', () => {
     })
   })
 
+  describe('ContentPlaceholder', () => {
+    it('Creates a snapshot for all arrangement of content placeholders', () => {
+      cy.visit('/#Basics/ContentPlaceholder/United')
+      cy.percySnapshot('ContentPlaceholder')
+    })
+  })
+
   describe('Paginators', () => {
     it('Creates the Paginators page snapshot', () => {
       cy.visit('/#Complex%20components/Paginators/NonNumeric')

--- a/elm.json
+++ b/elm.json
@@ -10,6 +10,7 @@
         "UI.Badge",
         "UI.Button",
         "UI.Checkbox",
+        "UI.ContentPlaceholder",
         "UI.Effect",
         "UI.Icon",
         "UI.Link",

--- a/i18n/English.json
+++ b/i18n/English.json
@@ -54,5 +54,11 @@
         "expand": "Expand sidebar",
         "collapse": "Minimize sidebar",
         "previous": "Go back"
+    },
+    "contentPlaceholders": {
+        "nothingToSeeHere": {
+            "title": "Nothing to see here",
+            "body": "Look, you tried looking here. It’s ok, life can be difficult at times when we don’t find what we’re looking for..."
+        }
     }
 }

--- a/i18n/French.json
+++ b/i18n/French.json
@@ -54,5 +54,11 @@
         "expand": "Elargir la barre latérale",
         "collapse": "Réduire la barre latérale",
         "previous": "Retourner"
+    },
+    "contentPlaceholders": {
+        "nothingToSeeHere": {
+            "title": "Nothing to see here",
+            "body": "Look, you tried looking here. It’s ok, life can be difficult at times when we don’t find what we’re looking for..."
+        }
     }
 }

--- a/i18n/Spanish.json
+++ b/i18n/Spanish.json
@@ -54,5 +54,11 @@
         "expand": "Expandir barra lateral",
         "collapse": "Minimizar barra lateral",
         "previous": "Atrás"
+    },
+    "contentPlaceholders": {
+        "nothingToSeeHere": {
+            "title": "Nothing to see here",
+            "body": "Look, you tried looking here. It’s ok, life can be difficult at times when we don’t find what we’re looking for..."
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "elm-test": "^0.19.1-revision6",
     "i18n-json-to-elm": "^1.1.2",
     "node-elm-compiler": "^5.0.4",
-    "paack-ui-assets": "^0.1.0",
+    "paack-ui-assets": "^0.1.1",
     "parcel-bundler": "^1.12.4",
     "parcel-plugin-asset-copier": "^1.1.0"
   },

--- a/showcase/src/ContentPlaceholders.elm
+++ b/showcase/src/ContentPlaceholders.elm
@@ -1,0 +1,168 @@
+module ContentPlaceholders exposing (stories)
+
+import Element exposing (Element, fill)
+import PluginOptions exposing (defaultWithMenu)
+import UI.ContentPlaceholder as ContentPlaceholder exposing (ContentPlaceholder)
+import UI.Icon as Icon
+import UI.RenderConfig exposing (RenderConfig)
+import UI.Text as Text
+import UIExplorer exposing (storiesOf)
+import Utils
+    exposing
+        ( ExplorerStory
+        , ExplorerUI
+        , goToDocsCallToAction
+        , iconsSvgSprite
+        , mobileRenderConfig
+        , prettifyElmCode
+        , story
+        )
+
+
+stories : RenderConfig -> ExplorerUI
+stories renderConfig =
+    storiesOf
+        "ContentPlaceholder"
+        [ desktopStory renderConfig
+        , mobileStory
+        , customStory renderConfig
+        , unitedStory renderConfig
+        ]
+
+
+desktopStory : RenderConfig -> ExplorerStory
+desktopStory renderConfig =
+    story
+        ( "Nothing to see here (Dekstop)"
+        , nothingToSeeHereView renderConfig
+            |> withIconSpreadsheet
+        , { defaultWithMenu
+            | code = nothingToSeeHereCode
+            , note = goToDocsCallToAction "ContentPlaceholder"
+          }
+        )
+
+
+mobileStory : ExplorerStory
+mobileStory =
+    story
+        ( "Nothing to see here (Mobile)"
+        , nothingToSeeHereView mobileRenderConfig
+            |> withIconSpreadsheet
+        , { defaultWithMenu
+            | code = nothingToSeeHereCode
+            , note = goToDocsCallToAction "ContentPlaceholder"
+          }
+        )
+
+
+nothingToSeeHereCode : String
+nothingToSeeHereCode =
+    prettifyElmCode """
+    ContentPlaceholder.nothingToSeeHereView
+        |> ContentPlaceholder.withLargeSize
+        |> ContentPlaceholder.renderElement renderConfig
+"""
+
+
+customStory : RenderConfig -> ExplorerStory
+customStory renderConfig =
+    story
+        ( "Custom"
+        , customView renderConfig
+            |> withIconSpreadsheet
+        , { defaultWithMenu
+            | code = customCode
+            , note = goToDocsCallToAction "ContentPlaceholder"
+          }
+        )
+
+
+nothingToSeeHereView : RenderConfig -> Element msg
+nothingToSeeHereView renderConfig =
+    Element.row [ Element.width fill ]
+        [ genericView "Large"
+            renderConfig
+            True
+            ContentPlaceholder.nothingToSeeHere
+        , genericView "Medium"
+            renderConfig
+            False
+            ContentPlaceholder.nothingToSeeHere
+        ]
+
+
+customView : RenderConfig -> Element msg
+customView renderConfig =
+    let
+        customState =
+            ContentPlaceholder.custom
+                { icon = Icon.fix
+                , title = "Select A Group"
+                , body = "Please select a group to fix from the list on the left."
+                }
+    in
+    Element.row [ Element.width fill ]
+        [ genericView "Large/Desktop"
+            renderConfig
+            True
+            customState
+        , genericView "Large/Mobile"
+            mobileRenderConfig
+            True
+            customState
+        ]
+
+
+genericView : String -> RenderConfig -> Bool -> ContentPlaceholder -> Element msg
+genericView label renderConfig isLarge component =
+    let
+        applyLargeSize =
+            if isLarge then
+                ContentPlaceholder.withLargeSize
+
+            else
+                identity
+    in
+    Element.column [ Element.width fill ]
+        [ Text.heading2 label
+            |> Text.renderElement renderConfig
+        , component
+            |> applyLargeSize
+            |> ContentPlaceholder.renderElement renderConfig
+        ]
+
+
+customCode : String
+customCode =
+    prettifyElmCode """
+    ContentPlaceholder.custom
+        { icon = Icon.fix
+        , title = "Select A Group"
+        , body = "Please select a group to fix from the list on the left."
+        }
+        |> ContentPlaceholder.withLargeSize
+        |> ContentPlaceholder.renderElement renderConfig
+"""
+
+
+withIconSpreadsheet : Element msg -> Element msg
+withIconSpreadsheet element =
+    Element.column [ Element.width fill ]
+        [ iconsSvgSprite
+        , element
+        ]
+
+
+unitedStory : RenderConfig -> ExplorerStory
+unitedStory renderConfig =
+    story
+        ( "United"
+        , Element.column [ Element.width fill ]
+            [ iconsSvgSprite
+            , customView renderConfig
+            , nothingToSeeHereView renderConfig
+            , nothingToSeeHereView mobileRenderConfig
+            ]
+        , defaultWithMenu
+        )

--- a/showcase/src/Main.elm
+++ b/showcase/src/Main.elm
@@ -4,6 +4,7 @@ import Alerts
 import Badges
 import Buttons.Stories as Buttons
 import Checkboxes.Stories as Checkboxes
+import ContentPlaceholders
 import Dialog
 import Html exposing (Html, div, img)
 import Html.Attributes exposing (src, style)
@@ -121,6 +122,7 @@ main =
             , Radio.stories renderConfig
             , Tabs.stories renderConfig
             , Layouts.stories renderConfig
+            , ContentPlaceholders.stories renderConfig
             ]
         |> category
             "Complex components"

--- a/showcase/src/Tables/Stories.elm
+++ b/showcase/src/Tables/Stories.elm
@@ -7,7 +7,7 @@ import Tables.Book as Book exposing (Book)
 import Tables.Model as Stories
 import Tables.Msg as Stories
 import UI.Effect as Effect
-import UI.RenderConfig as RenderConfig exposing (RenderConfig)
+import UI.RenderConfig exposing (RenderConfig)
 import UI.Tables.Common as Tables
 import UI.Tables.Stateful as Stateful
 import UI.Tables.Stateless as Stateless
@@ -18,6 +18,7 @@ import Utils
         ( ExplorerStory
         , ExplorerUI
         , iconsSvgSprite
+        , mobileRenderConfig
         , reducedToDocs
         , storyWithModel
         )
@@ -70,7 +71,7 @@ mobileTableStory =
     storyWithModel
         ( "Mobile"
         , \{ tablesStories } ->
-            demoTable mobileCfg
+            demoTable mobileRenderConfig
                 Book.tablePixelColumns
                 tablesStories.mainTableState
                 Stories.ForMain
@@ -110,13 +111,6 @@ withIcons table =
         |> List.singleton
         |> (::) iconsSvgSprite
         |> Element.wrappedRow [ Element.width fill ]
-
-
-mobileCfg : RenderConfig
-mobileCfg =
-    RenderConfig.init
-        { width = 375, height = 667 }
-        RenderConfig.localeEnglish
 
 
 statelessTableStory : RenderConfig -> ExplorerStory

--- a/showcase/src/Utils.elm
+++ b/showcase/src/Utils.elm
@@ -4,6 +4,7 @@ module Utils exposing
     , ExplorerUI
     , goToDocsCallToAction
     , iconsSvgSprite
+    , mobileRenderConfig
     , prettifyElmCode
     , reducedToDocs
     , story
@@ -19,6 +20,7 @@ import Model exposing (Model)
 import Msg exposing (Msg)
 import PluginOptions exposing (PluginOptions, defaultWithMenu)
 import UI.Palette as Palette exposing (brightnessMiddle, toneGray)
+import UI.RenderConfig as RenderConfig exposing (RenderConfig)
 import UIExplorer
 
 
@@ -108,3 +110,10 @@ reducedToDocs path =
                 ++ path
                 ++ ") for the exact code of this example."
     }
+
+
+mobileRenderConfig : RenderConfig
+mobileRenderConfig =
+    RenderConfig.init
+        { width = 375, height = 667 }
+        RenderConfig.localeEnglish

--- a/src/I18n/English.elm
+++ b/src/I18n/English.elm
@@ -106,6 +106,19 @@ sidebar =
     }
 
 
+contentPlaceholdersNothingToSeeHere : ContentPlaceholdersNothingToSeeHere
+contentPlaceholdersNothingToSeeHere =
+    { title = "Nothing to see here"
+    , body = "Look, you tried looking here. It’s ok, life can be difficult at times when we don’t find what we’re looking for..."
+    }
+
+
+contentPlaceholders : ContentPlaceholders
+contentPlaceholders =
+    { nothingToSeeHere = contentPlaceholdersNothingToSeeHere
+    }
+
+
 root : Root
 root =
     { filters = filters
@@ -117,4 +130,5 @@ root =
     , dateInput = dateInput
     , dialog = dialog
     , sidebar = sidebar
+    , contentPlaceholders = contentPlaceholders
     }

--- a/src/I18n/French.elm
+++ b/src/I18n/French.elm
@@ -81,8 +81,8 @@ tables : Tables
 tables =
     { details = tablesDetails
     , sorting = tablesSorting
-    , selectRow = "Select this row."
-    , selectAll = "Select all rows"
+    , selectRow = "Sélectionner la ligne"
+    , selectAll = "Sélectionner toutes les lignes"
     }
 
 
@@ -106,6 +106,19 @@ sidebar =
     }
 
 
+contentPlaceholdersNothingToSeeHere : ContentPlaceholdersNothingToSeeHere
+contentPlaceholdersNothingToSeeHere =
+    { title = "Nothing to see here"
+    , body = "Look, you tried looking here. It’s ok, life can be difficult at times when we don’t find what we’re looking for..."
+    }
+
+
+contentPlaceholders : ContentPlaceholders
+contentPlaceholders =
+    { nothingToSeeHere = contentPlaceholdersNothingToSeeHere
+    }
+
+
 root : Root
 root =
     { filters = filters
@@ -117,4 +130,5 @@ root =
     , dateInput = dateInput
     , dialog = dialog
     , sidebar = sidebar
+    , contentPlaceholders = contentPlaceholders
     }

--- a/src/I18n/Spanish.elm
+++ b/src/I18n/Spanish.elm
@@ -106,6 +106,19 @@ sidebar =
     }
 
 
+contentPlaceholdersNothingToSeeHere : ContentPlaceholdersNothingToSeeHere
+contentPlaceholdersNothingToSeeHere =
+    { title = "Nothing to see here"
+    , body = "Look, you tried looking here. It’s ok, life can be difficult at times when we don’t find what we’re looking for..."
+    }
+
+
+contentPlaceholders : ContentPlaceholders
+contentPlaceholders =
+    { nothingToSeeHere = contentPlaceholdersNothingToSeeHere
+    }
+
+
 root : Root
 root =
     { filters = filters
@@ -117,4 +130,5 @@ root =
     , dateInput = dateInput
     , dialog = dialog
     , sidebar = sidebar
+    , contentPlaceholders = contentPlaceholders
     }

--- a/src/I18n/Types.elm
+++ b/src/I18n/Types.elm
@@ -90,6 +90,17 @@ type alias Sidebar =
     }
 
 
+type alias ContentPlaceholdersNothingToSeeHere =
+    { title : String
+    , body : String
+    }
+
+
+type alias ContentPlaceholders =
+    { nothingToSeeHere : ContentPlaceholdersNothingToSeeHere
+    }
+
+
 type alias Root =
     { filters : Filters
     , paginator : Paginator
@@ -100,4 +111,5 @@ type alias Root =
     , dateInput : DateInput
     , dialog : Dialog
     , sidebar : Sidebar
+    , contentPlaceholders : ContentPlaceholders
     }

--- a/src/UI/ContentPlaceholder.elm
+++ b/src/UI/ContentPlaceholder.elm
@@ -1,0 +1,248 @@
+module UI.ContentPlaceholder exposing
+    ( ContentPlaceholder
+    , custom
+    , nothingToSeeHere
+    , withLargeSize
+    , renderElement
+    )
+
+{-| `UI.ContentPlaceholders` fills space in an area that is waiting for some action from the user.
+
+An content-placeholder can be created and rendered as in the following pipeline:
+
+    ContentPlaceholders.custom
+        { icon = Icon.fix
+        , title = "Select A Group"
+        , body = "Please select a group to fix from the list on the left."
+        }
+        |> ContentPlaceholders.withSize Size.large
+        |> ContentPlaceholders.renderElement renderConfig
+
+There are also some ready-to-use costructors.
+
+
+# Building
+
+@docs ContentPlaceholder
+@docs custom
+
+
+# Common values
+
+@docs nothingToSeeHere
+
+
+# Size
+
+@docs withLargeSize
+
+
+# Rendering
+
+@docs renderElement
+
+-}
+
+import Element exposing (Element, fill, maximum)
+import Element.Font as Font
+import UI.Icon as Icon exposing (Icon)
+import UI.Internal.RenderConfig exposing (localeTerms)
+import UI.Internal.Size exposing (Size(..))
+import UI.Palette as Palette exposing (brightnessLight, toneGray)
+import UI.RenderConfig as RenderConfig exposing (RenderConfig)
+import UI.Text as Text
+import UI.Utils.Element as Element
+
+
+{-| The `ContentPlaceholder` type is used for describing the component for later rendering.
+-}
+type ContentPlaceholder
+    = Custom Properties Options
+    | NothingToSeeHere Options
+
+
+type alias Properties =
+    { icon : String -> Icon
+    , title : String
+    , body : String
+    }
+
+
+type alias Options =
+    { size : Size }
+
+
+{-| Constructs a generic `ContentPlaceholder`.
+
+    ContentPlaceholders.custom
+        { icon = Icon.download
+        , title = "Pick a file"
+        , body = "Please select a file to download it."
+        }
+        |> ContentPlaceholders.renderElement renderConfig
+
+-}
+custom :
+    { icon : String -> Icon
+    , title : String
+    , body : String
+    }
+    -> ContentPlaceholder
+custom prop =
+    Custom prop defaultOptions
+
+
+{-| One of the ready-to-use constructors.
+Used in impossible-states and empty unmanaged lists.
+
+    ContentPlaceholders.nothingToSeeHere
+        |> ContentPlaceholders.renderElement renderConfig
+
+-}
+nothingToSeeHere : ContentPlaceholder
+nothingToSeeHere =
+    NothingToSeeHere defaultOptions
+
+
+defaultOptions : Options
+defaultOptions =
+    { size = Medium }
+
+
+{-| With `withSize`, you'll be able to scale the icon and text between the [standard sizes][size].
+
+[size]: UI-Size
+
+    ContentPlaceholders.withSize Size.medium somePlaceholder
+
+**NOTE**: Default value is [`Size.medium`](UI-Size#medium).
+
+-}
+withSize : Size -> ContentPlaceholder -> ContentPlaceholder
+withSize newSize component =
+    setOption (\opt -> { opt | size = newSize }) component
+
+
+{-| With `withLargeSize`, you'll have a larger `ContentPlaceholder`.
+
+    ContentPlaceholders.withLargeSize somePlaceholder
+
+**NOTE**: Default size is [`Size.medium`](UI-Size#medium).
+
+-}
+withLargeSize : ContentPlaceholder -> ContentPlaceholder
+withLargeSize component =
+    withSize Large component
+
+
+setOption : (Options -> Options) -> ContentPlaceholder -> ContentPlaceholder
+setOption applier component =
+    case component of
+        Custom prop opt ->
+            Custom prop <| applier opt
+
+        NothingToSeeHere opt ->
+            NothingToSeeHere <| applier opt
+
+
+getProp : RenderConfig -> ContentPlaceholder -> Properties
+getProp renderConfig component =
+    case component of
+        Custom prop _ ->
+            prop
+
+        NothingToSeeHere _ ->
+            let
+                { title, body } =
+                    (localeTerms renderConfig).contentPlaceholders.nothingToSeeHere
+            in
+            { icon = Icon.configure
+            , title = title
+            , body = body
+            }
+
+
+getOpt : ContentPlaceholder -> Options
+getOpt component =
+    case component of
+        Custom _ opt ->
+            opt
+
+        NothingToSeeHere opt ->
+            opt
+
+
+{-| End of the builder's life.
+The result of component function is a ready-to-insert Elm UI's Element.
+-}
+renderElement : RenderConfig -> ContentPlaceholder -> Element msg
+renderElement renderConfig component =
+    let
+        { title, icon, body } =
+            getProp renderConfig component
+
+        { size } =
+            getOpt component
+
+        isLarge =
+            size == Large
+
+        titleText =
+            case ( isLarge, RenderConfig.isMobile renderConfig ) of
+                ( True, True ) ->
+                    Text.heading5
+
+                ( False, True ) ->
+                    Text.heading6
+
+                ( True, False ) ->
+                    Text.heading4
+
+                ( False, False ) ->
+                    Text.heading5
+
+        ( bodyText, iconPadding, iconSize ) =
+            if isLarge then
+                ( Text.body1, largeIconPadding, 96 )
+
+            else
+                ( Text.body2, mediumIconPadding, 80 )
+    in
+    Element.column
+        [ Element.width (fill |> maximum 300)
+        , Element.centerX
+        , Element.centerY
+        , Element.spacing 8
+        , Font.center
+        ]
+        [ icon title
+            |> Icon.withCustomSize iconSize
+            |> Icon.withColor (Palette.color toneGray brightnessLight)
+            |> Icon.renderElement renderConfig
+            |> Element.el
+                [ Element.centerX
+                , Element.paddingEach iconPadding
+                ]
+        , titleText title
+            |> Text.renderElement renderConfig
+        , bodyText body
+            |> Text.renderElement renderConfig
+        ]
+
+
+mediumIconPadding : Element.RectangleSides
+mediumIconPadding =
+    { top = 24
+    , left = 0
+    , right = 0
+    , bottom = 12
+    }
+
+
+largeIconPadding : Element.RectangleSides
+largeIconPadding =
+    { top = 22
+    , left = 0
+    , right = 0
+    , bottom = 14
+    }

--- a/src/UI/Icon.elm
+++ b/src/UI/Icon.elm
@@ -1,11 +1,11 @@
 module UI.Icon exposing
     ( svgSpriteImport
     , Icon
-    , add, check, close, collapse, download, edit, eventLog, expand, filter
-    , groups, logout, move, nextContent, notifications, paackSpaces, packages
-    , previousContent, print, remove, sandwichMenu, search, searchSpace
-    , seeMore, toggle, toggleDown, toggleUp, delete, warning
-    , sortDecreasing, sortIncreasing
+    , add, check, close, collapse, configure, download, edit, fix, eventLog
+    , expand, filter, groups, logout, move, nextContent, notifications
+    , paackSpaces, packages, previousContent, print, remove, sandwichMenu
+    , search, searchSpace, seeMore, sortDecreasing, sortIncreasing, toggle
+    , toggleDown, toggleUp, delete, warning
     , getHint
     , withColor
     , withSize, withCustomSize
@@ -36,11 +36,11 @@ An icon can be created and rendered as in the following pipeline:
 # Building
 
 @docs Icon
-@docs add, check, close, collapse, download, edit, eventLog, expand, filter
-@docs groups, logout, move, nextContent, notifications, paackSpaces, packages
-@docs previousContent, print, remove, sandwichMenu, search, searchSpace
-@docs seeMore, toggle, toggleDown, toggleUp, delete, warning
-@docs sortDecreasing, sortIncreasing
+@docs add, check, close, collapse, configure, download, edit, fix, eventLog
+@docs expand, filter, groups, logout, move, nextContent, notifications
+@docs paackSpaces, packages, previousContent, print, remove, sandwichMenu
+@docs search, searchSpace, seeMore, sortDecreasing, sortIncreasing, toggle
+@docs toggleDown, toggleUp, delete, warning
 
 
 # Disassemble
@@ -106,6 +106,7 @@ type IconGlyph
     | Check
     | Close
     | Collapse
+    | Configure
     | Delete
     | DownArrow
     | Download
@@ -113,6 +114,7 @@ type IconGlyph
     | EventLog
     | Expand
     | Filter
+    | Fix
     | Groups
     | Logout
     | Move
@@ -265,6 +267,16 @@ check hint =
 close : String -> Icon
 close hint =
     Icon (Properties hint Close) defaultOptions
+
+
+{-| A gear. Usually used for opening settings managers.
+
+    Icon.configure "Open display settings"
+
+-}
+configure : String -> Icon
+configure hint =
+    Icon (Properties hint Configure) defaultOptions
 
 
 {-| Tree-bar stacked vertically.
@@ -491,6 +503,16 @@ sortDecreasing hint =
     Icon (Properties hint SortDecreasing) defaultOptions
 
 
+{-| A monkey wrench.
+
+    Icon.fix "Fix all invalid values"
+
+-}
+fix : String -> Icon
+fix hint =
+    Icon (Properties hint Fix) defaultOptions
+
+
 
 -- Rendering
 
@@ -535,6 +557,9 @@ renderElement _ (Icon { hint, glyph } { color, size }) =
             Collapse ->
                 svgIcon "Collapse"
 
+            Configure ->
+                svgIcon "Settings"
+
             Delete ->
                 svgIcon "Trash"
 
@@ -555,6 +580,9 @@ renderElement _ (Icon { hint, glyph } { color, size }) =
 
             Filter ->
                 svgIcon "Filter"
+
+            Fix ->
+                svgIcon "Fix"
 
             Groups ->
                 svgIcon "Groups"

--- a/src/UI/SummaryListItem.elm
+++ b/src/UI/SummaryListItem.elm
@@ -1,6 +1,7 @@
 module UI.SummaryListItem exposing (view)
 
-{-| SummaryListItem is represents a single item in a list that is usually selectable or searchable. This component is meant to be used with [`ListView`](UI-ListView).
+{-| `SummaryListItem` represents a single item in a list that is usually selectable or searchable.
+This component is meant to be used with [`ListView`](UI-ListView).
 
     import UI.SummaryListItem as Summary
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5590,10 +5590,10 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-paack-ui-assets@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/paack-ui-assets/-/paack-ui-assets-0.1.0.tgz#3efbd3a86a854f0e86c5ffe450ea21eef2273cf7"
-  integrity sha512-auag6q6bTZmwHkk9JyBejLIThVOyGqzY6cyFt9LCqI6O01hCrRF538+0Himd16wfyPPcvjP+B2iL/V/WVfajzg==
+paack-ui-assets@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/paack-ui-assets/-/paack-ui-assets-0.1.1.tgz#6a9f82931263644309a951add288053e733f4b2d"
+  integrity sha512-UpFjbcxN+0TG7+f6mkcp1ReIrXCySHPD8oKgQXk7CPlUSGGWgBEoaDHC5i8PSQ+BGJUMh01CSYTeczF/0Xt2uQ==
 
 package-json@^6.3.0:
   version "6.5.0"


### PR DESCRIPTION
#### :thinking: What?

Implements this baby: https://www.figma.com/file/piyT6sDqja7yG7QarvmAZ9/Empty-States


#### :man_shrugging: Why?

* Good guy Sufyian noticed this pattern repeating a lot between screens and decided to upgrade it to a component.
* We're using this [in WMS Phase 4](https://www.figma.com/file/DTyoSveNksHpZCdU8a7BNs/Dashboard?node-id=1855%3A26417)

#### :pushpin: Jira Issue

[WMS-801](https://paacklogistics.atlassian.net/browse/WMS-801)


#### :no_good: Blocked by

* ~I need to add that "Fix" icon into paack-ui-assets.~ SOLVED


#### :clipboard: Pending

- [x] Documentation.
- [x] Add terms to POEditor.
