### PR TITLE
WMS-812 | Sort direction instead of reverse

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",

--- a/src/UI/Internal/Analytics.elm
+++ b/src/UI/Internal/Analytics.elm
@@ -51,7 +51,14 @@ encodeTable analytics =
         SetSorting column reverse ->
             [ encodeAction "set_sorting"
             , encodeColumn column
-            , ( "reverse", Encode.bool reverse )
+            , ( "direction"
+              , Encode.string <|
+                    if reverse then
+                        "descending"
+
+                    else
+                        "ascending"
+              )
             ]
 
         ClearSorting ->


### PR DESCRIPTION
#### :thinking: What?

When sorting tables' columns:
* Instead of `reverse=true`, register it as `direction=descending`;
* Instead of `reverse=false`, register it as `direction=ascending`;


#### :man_shrugging: Why?

* It was confusing to see it as it's in Mixpanel.


#### :pushpin: Jira Issue

Not tracked.


#### :no_good: Blocked by

Not blocked.


#### :clipboard: Pending
Nothing.