### PR TITLE
WMS-802 | Add checkbox support to SummaryListItem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
 
-     - uses: PaackEng/elm-lint-action@main
+     - uses: PaackEng/elm-validate-action@main
        with:
          elm-working-directory: 'showcase'
          extra-path: '../src'

--- a/elm.json
+++ b/elm.json
@@ -15,6 +15,7 @@
         "UI.Icon",
         "UI.Link",
         "UI.ListView",
+        "UI.ListView.SummaryItem",
         "UI.LoadingView",
         "UI.NavigationContainer",
         "UI.Paginator",
@@ -36,7 +37,6 @@
         "UI.Utils.Focus",
         "UI.Utils.TypeNumbers",
         "UI.V2.Dialog",
-        "UI.V2.SummaryListItem",
         "UI.Layout.SplitSelectable"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",

--- a/elm.json
+++ b/elm.json
@@ -36,6 +36,7 @@
         "UI.Utils.Focus",
         "UI.Utils.TypeNumbers",
         "UI.V2.Dialog",
+        "UI.V2.SummaryListItem",
         "UI.Layout.SplitSelectable"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",

--- a/showcase/src/Layouts/Stories.elm
+++ b/showcase/src/Layouts/Stories.elm
@@ -9,16 +9,17 @@ import PluginOptions exposing (defaultWithoutMenu)
 import Return exposing (Return)
 import Tables.Book exposing (Book, books)
 import UI.Badge as Badge
+import UI.Checkbox as Checkbox
 import UI.Internal.NavigationContainer
 import UI.Layout.SplitSelectable as SplitSelectable
 import UI.ListView as ListView exposing (ListView)
 import UI.Palette as Palette exposing (brightnessLighter, tonePrimary)
 import UI.RenderConfig exposing (RenderConfig)
-import UI.SummaryListItem as Summary
 import UI.Text as Text
+import UI.V2.SummaryListItem as Summary
+import UI.Palette as Palette
 import UIExplorer exposing (storiesOf)
-import Utils exposing (ExplorerStory, ExplorerUI, prettifyElmCode, storyBorder, storyWithModel)
-
+import Utils exposing (ExplorerStory, ExplorerUI, prettifyElmCode, storyList, storyBorder, storyWithModel, iconsSvgSprite)
 
 update : LayoutsMsg.Msg -> LayoutsModel.Model -> Return LayoutsMsg.Msg LayoutsModel.Model
 update msg model =
@@ -45,7 +46,11 @@ demo : RenderConfig -> ExplorerStory
 demo renderConfig =
     storyWithModel
         ( "SplitSelectable"
-        , storyBorder << view renderConfig
+        , view renderConfig
+            >> storyBorder
+            >> List.singleton
+            >> (::) iconsSvgSprite
+            >> Element.column []
         , { defaultWithoutMenu | code = code }
         )
 
@@ -129,11 +134,10 @@ bookHasString str { title } =
 
 listItemView : RenderConfig -> Bool -> Book -> Element Msg
 listItemView renderConfig isSelected book =
-    Summary.view renderConfig
-        isSelected
-        book.title
-        book.author
-        (Badge.grayLight <| String.fromInt 1)
+    Summary.summaryListItem book.title book.author
+        |> Summary.withBadge (Badge.grayLight <| String.fromInt 1)
+        |> Summary.withSelected isSelected
+        |> Summary.renderElement renderConfig
 
 
 code : String

--- a/showcase/src/Layouts/Stories.elm
+++ b/showcase/src/Layouts/Stories.elm
@@ -17,9 +17,9 @@ import UI.Palette as Palette exposing (brightnessLighter, tonePrimary)
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Text as Text
 import UI.V2.SummaryListItem as Summary
-import UI.Palette as Palette
 import UIExplorer exposing (storiesOf)
-import Utils exposing (ExplorerStory, ExplorerUI, prettifyElmCode, storyList, storyBorder, storyWithModel, iconsSvgSprite)
+import Utils exposing (ExplorerStory, ExplorerUI, iconsSvgSprite, prettifyElmCode, storyBorder, storyList, storyWithModel)
+
 
 update : LayoutsMsg.Msg -> LayoutsModel.Model -> Return LayoutsMsg.Msg LayoutsModel.Model
 update msg model =

--- a/showcase/src/Layouts/Stories.elm
+++ b/showcase/src/Layouts/Stories.elm
@@ -12,10 +12,10 @@ import UI.Badge as Badge
 import UI.Internal.NavigationContainer
 import UI.Layout.SplitSelectable as SplitSelectable
 import UI.ListView as ListView exposing (ListView)
+import UI.ListView.SummaryItem as Summary
 import UI.Palette as Palette exposing (brightnessLighter, tonePrimary)
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Text as Text
-import UI.V2.SummaryListItem as Summary
 import UIExplorer exposing (storiesOf)
 import Utils exposing (ExplorerStory, ExplorerUI, iconsSvgSprite, prettifyElmCode, storyBorder, storyWithModel)
 
@@ -133,7 +133,7 @@ bookHasString str { title } =
 
 listItemView : RenderConfig -> Bool -> Book -> Element Msg
 listItemView renderConfig isSelected book =
-    Summary.summaryListItem book.title book.author
+    Summary.summaryItem book.title book.author
         |> Summary.withBadge (Badge.grayLight <| String.fromInt 1)
         |> Summary.withSelected isSelected
         |> Summary.renderElement renderConfig

--- a/showcase/src/Layouts/Stories.elm
+++ b/showcase/src/Layouts/Stories.elm
@@ -9,7 +9,6 @@ import PluginOptions exposing (defaultWithoutMenu)
 import Return exposing (Return)
 import Tables.Book exposing (Book, books)
 import UI.Badge as Badge
-import UI.Checkbox as Checkbox
 import UI.Internal.NavigationContainer
 import UI.Layout.SplitSelectable as SplitSelectable
 import UI.ListView as ListView exposing (ListView)
@@ -18,7 +17,7 @@ import UI.RenderConfig exposing (RenderConfig)
 import UI.Text as Text
 import UI.V2.SummaryListItem as Summary
 import UIExplorer exposing (storiesOf)
-import Utils exposing (ExplorerStory, ExplorerUI, iconsSvgSprite, prettifyElmCode, storyBorder, storyList, storyWithModel)
+import Utils exposing (ExplorerStory, ExplorerUI, iconsSvgSprite, prettifyElmCode, storyBorder, storyWithModel)
 
 
 update : LayoutsMsg.Msg -> LayoutsModel.Model -> Return LayoutsMsg.Msg LayoutsModel.Model

--- a/showcase/src/Layouts/Stories.elm
+++ b/showcase/src/Layouts/Stories.elm
@@ -49,7 +49,7 @@ demo renderConfig =
             >> storyBorder
             >> List.singleton
             >> (::) iconsSvgSprite
-            >> Element.column []
+            >> Element.column [ Element.width fill ]
         , { defaultWithoutMenu | code = code }
         )
 

--- a/showcase/src/Radio/Stories.elm
+++ b/showcase/src/Radio/Stories.elm
@@ -4,7 +4,7 @@ import Element exposing (Element)
 import Model exposing (Model)
 import Msg exposing (Msg)
 import PluginOptions exposing (defaultWithMenu)
-import Radio.Model as RadioModel exposing (Options(..))
+import Radio.Model as RadioModel exposing (Options)
 import Radio.Msg as RadioMsg
 import Return exposing (Return)
 import UI.Radio as Radio

--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -87,7 +87,6 @@ import UI.Internal.Text as Text exposing (TextColor)
 import UI.Link as Link exposing (Link)
 import UI.Palette as Palette exposing (brightnessDarkest, brightnessLight, brightnessLighter, brightnessLightest, brightnessMiddle, tonePrimary)
 import UI.RenderConfig exposing (RenderConfig)
-import UI.Text as Text
 import UI.Utils.ARIA as ARIA
 import UI.Utils.Element as Element
 

--- a/src/UI/Internal/Button.elm
+++ b/src/UI/Internal/Button.elm
@@ -18,7 +18,6 @@ import UI.Icon as Icon exposing (Icon)
 import UI.Internal.Size as Size exposing (Size)
 import UI.Link exposing (Link)
 import UI.RenderConfig exposing (RenderConfig)
-import UI.Utils.Element as Element
 
 
 type alias Options =

--- a/src/UI/Internal/Dialog.elm
+++ b/src/UI/Internal/Dialog.elm
@@ -11,7 +11,7 @@ import UI.RenderConfig as RenderConfig exposing (RenderConfig)
 import UI.Size as Size
 import UI.Text as Text
 import UI.Utils.ARIA as ARIA
-import UI.Utils.Element as Element exposing (RectangleSides)
+import UI.Utils.Element exposing (RectangleSides)
 
 
 type alias Dialog msg =

--- a/src/UI/Internal/DialogV2.elm
+++ b/src/UI/Internal/DialogV2.elm
@@ -11,7 +11,7 @@ import UI.Palette as Palette
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
 import UI.Size as Size
 import UI.Text as Text
-import UI.Utils.Element as Element exposing (RectangleSides)
+import UI.Utils.Element exposing (RectangleSides)
 import UI.V2.Dialog as Dialog
 
 

--- a/src/UI/Internal/Nav/StackHeader.elm
+++ b/src/UI/Internal/Nav/StackHeader.elm
@@ -12,7 +12,7 @@ import UI.RenderConfig exposing (RenderConfig)
 import UI.Size as Size
 import UI.Text as Text exposing (ellipsize)
 import UI.Utils.Action as Action
-import UI.Utils.Element as Element exposing (zeroPadding)
+import UI.Utils.Element exposing (zeroPadding)
 
 
 type LeftButton msg

--- a/src/UI/Internal/Text.elm
+++ b/src/UI/Internal/Text.elm
@@ -28,7 +28,6 @@ import UI.Internal.Basics exposing (ifThenElse)
 import UI.Internal.Utils.Element exposing (overflowAttrs, overflowVisible)
 import UI.Palette as Palette exposing (brightnessDarkest, toneGray)
 import UI.RenderConfig exposing (RenderConfig, isMobile)
-import UI.Utils.Element as Element
 
 
 type Text

--- a/src/UI/ListView/SummaryItem.elm
+++ b/src/UI/ListView/SummaryItem.elm
@@ -1,17 +1,17 @@
-module UI.V2.SummaryListItem exposing
-    ( SummaryListItem, summaryListItem
+module UI.ListView.SummaryItem exposing
+    ( SummaryItem, summaryItem
     , withSelected, withBadge, withCheckbox
     , renderElement
     )
 
-{-| `SummaryListItem` represents a single item in a list that is usually selectable or searchable.
+{-| `SummaryItem` represents a single item in a list that is usually selectable or searchable.
 This component is meant to be used with [`ListView`](UI-ListView).
 
-    import UI.V2.SummaryListItem as Summary
+    import UI.ListView.SummaryItem as Summary
 
     listItemView : AppConfig -> Bool -> Item -> Element Msg
     listItemView appConfig isSelected item =
-        Summary.summaryListItem item.name item.subtitle
+        Summary.summaryItem item.name item.subtitle
             |> Summary.withSelected isSelected
             |> Summary.withBadge (Badge.grayLight "badge")
             |> Summary.renderElement appConfig.renderConfig
@@ -27,7 +27,7 @@ This component is meant to be used with [`ListView`](UI-ListView).
 
 # Building
 
-@docs SummaryListItem, summaryListItem
+@docs SummaryItem, summaryItem
 
 
 # Options
@@ -62,11 +62,11 @@ import UI.Text as Text exposing (ellipsize)
 -- Building
 
 
-{-| The `SummaryListItem msg` type is used for describing the component for later
+{-| The `SummaryItem msg` type is used for describing the component for later
 rendering.
 -}
-type SummaryListItem msg
-    = SummaryListItem Properties (Options msg)
+type SummaryItem msg
+    = SummaryItem Properties (Options msg)
 
 
 type alias Properties =
@@ -84,12 +84,12 @@ type alias Options msg =
 
 {-| Constructs a summary by receiving its title and caption.
 
-    Summary.summaryListItem "Item title" "Item caption"
+    Summary.summaryItem "Item title" "Item caption"
 
 -}
-summaryListItem : String -> String -> SummaryListItem msg
-summaryListItem title caption =
-    SummaryListItem (Properties title caption) (Options False Nothing Nothing)
+summaryItem : String -> String -> SummaryItem msg
+summaryItem title caption =
+    SummaryItem (Properties title caption) (Options False Nothing Nothing)
 
 
 {-| Indicates whether the summary is selected or not.
@@ -98,9 +98,9 @@ summaryListItem title caption =
         someListView
 
 -}
-withSelected : Bool -> SummaryListItem msg -> SummaryListItem msg
-withSelected selected (SummaryListItem prop opt) =
-    SummaryListItem prop { opt | selected = selected }
+withSelected : Bool -> SummaryItem msg -> SummaryItem msg
+withSelected selected (SummaryItem prop opt) =
+    SummaryItem prop { opt | selected = selected }
 
 
 {-| Adds a badge to the right side of the summary.
@@ -109,9 +109,9 @@ withSelected selected (SummaryListItem prop opt) =
         someListView
 
 -}
-withBadge : Badge -> SummaryListItem msg -> SummaryListItem msg
-withBadge badge (SummaryListItem prop opt) =
-    SummaryListItem prop { opt | badge = Just badge }
+withBadge : Badge -> SummaryItem msg -> SummaryItem msg
+withBadge badge (SummaryItem prop opt) =
+    SummaryItem prop { opt | badge = Just badge }
 
 
 {-| Adds a checkbox to the left side of the summary.
@@ -120,16 +120,16 @@ withBadge badge (SummaryListItem prop opt) =
         someListView
 
 -}
-withCheckbox : Checkbox msg -> SummaryListItem msg -> SummaryListItem msg
-withCheckbox checkbox (SummaryListItem prop opt) =
-    SummaryListItem prop { opt | checkbox = Just checkbox }
+withCheckbox : Checkbox msg -> SummaryItem msg -> SummaryItem msg
+withCheckbox checkbox (SummaryItem prop opt) =
+    SummaryItem prop { opt | checkbox = Just checkbox }
 
 
 {-| End of the builder's life.
 The result of this function is a ready-to-insert Elm UI's Element.
 -}
-renderElement : RenderConfig -> SummaryListItem msg -> Element msg
-renderElement renderConfig (SummaryListItem { title, caption } opt) =
+renderElement : RenderConfig -> SummaryItem msg -> Element msg
+renderElement renderConfig (SummaryItem { title, caption } opt) =
     let
         colors =
             listItemColors opt

--- a/src/UI/NavigationContainer.elm
+++ b/src/UI/NavigationContainer.elm
@@ -96,7 +96,6 @@ import UI.Internal.SideBar as SideBar
 import UI.Link exposing (Link)
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
 import UI.Utils.Action as Action
-import UI.Utils.Element as Element
 import UI.V2.Dialog as Dialog2
 
 

--- a/src/UI/Radio.elm
+++ b/src/UI/Radio.elm
@@ -63,7 +63,6 @@ import UI.Palette as Palette
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Text as Text
 import UI.Utils.ARIA as ARIA
-import UI.Utils.Element as Element
 
 
 {-| The `RadioGroup id msg` type is used for describing the component for later rendering.

--- a/src/UI/Tabs.elm
+++ b/src/UI/Tabs.elm
@@ -34,10 +34,9 @@ import Element.Font as Font
 import Element.Input as Input
 import UI.Internal.Basics exposing (ifThenElse)
 import UI.Internal.Colors as Colors
-import UI.Internal.Utils.Element as Element
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Utils.ARIA as ARIA
-import UI.Utils.Element as Element exposing (zeroPadding)
+import UI.Utils.Element exposing (zeroPadding)
 
 
 {-| The `TabList msg a` type is used for describing the component for later rendering.

--- a/src/UI/V2/Dialog.elm
+++ b/src/UI/V2/Dialog.elm
@@ -33,7 +33,6 @@ it. Body and buttons can be specified optionally as in the following pipeline:
 import Element exposing (Element)
 import UI.Button as Button exposing (Button)
 import UI.Icon exposing (Icon)
-import UI.Utils.Element as Element
 
 
 

--- a/src/UI/V2/SummaryListItem.elm
+++ b/src/UI/V2/SummaryListItem.elm
@@ -7,7 +7,7 @@ module UI.V2.SummaryListItem exposing
 {-| `SummaryListItem` represents a single item in a list that is usually selectable or searchable.
 This component is meant to be used with [`ListView`](UI-ListView).
 
-    import UI.SummaryListItem as Summary
+    import UI.V2.SummaryListItem as Summary
 
     listItemView : AppConfig -> Bool -> Item -> Element Msg
     listItemView appConfig isSelected item =
@@ -84,11 +84,7 @@ type alias Options msg =
 
 {-| Constructs a summary by receiving its title and caption.
 
-    Summary.withItems
-        [ { id = 0, name = "Catarina" }
-        , { id = 1, name = "Gabriel" }
-        ]
-        someListView
+    Summary.summaryListItem "Item title" "Item caption"
 
 -}
 summaryListItem : String -> String -> SummaryListItem msg

--- a/src/UI/V2/SummaryListItem.elm
+++ b/src/UI/V2/SummaryListItem.elm
@@ -1,0 +1,248 @@
+module UI.V2.SummaryListItem exposing
+    ( SummaryListItem, summaryListItem
+    , withSelected, withBadge, withCheckbox
+    , renderElement
+    )
+
+{-| `SummaryListItem` represents a single item in a list that is usually selectable or searchable.
+This component is meant to be used with [`ListView`](UI-ListView).
+
+    import UI.SummaryListItem as Summary
+
+    listItemView : AppConfig -> Bool -> Item -> Element Msg
+    listItemView appConfig isSelected item =
+        Summary.summaryListItem item.name item.subtitle
+            |> Summary.withSelected isSelected
+            |> Summary.withBadge (Badge.grayLight "badge")
+            |> Summary.renderElement appConfig.renderConfig
+
+    listView : AppConfig -> Model -> ListView Item Msg
+    listView appConfig model =
+        listItemView appConfig
+            |> ListView.selectList Msg.Select Item.id
+            |> ListView.withSearchField (searchField appConfig model)
+            |> ListView.withActionBar (actionBar appConfig)
+            |> ListView.withDomId "item-list"
+
+
+# Building
+
+@docs SummaryListItem, summaryListItem
+
+
+# Options
+
+@docs withSelected, withBadge, withCheckbox
+
+
+# Rendering
+
+@docs renderElement
+
+-}
+
+import Element exposing (Element, fill)
+import Element.Keyed as Keyed
+import UI.Badge as Badge exposing (Badge)
+import UI.Checkbox as Checkbox exposing (Checkbox)
+import UI.Internal.Basics exposing (prependMaybe)
+import UI.Palette as Palette
+    exposing
+        ( brightnessLight
+        , brightnessLighter
+        , brightnessMiddle
+        , toneGray
+        , tonePrimary
+        )
+import UI.RenderConfig exposing (RenderConfig)
+import UI.Text as Text exposing (ellipsize)
+
+
+
+-- Building
+
+
+{-| The `SummaryListItem msg` type is used for describing the component for later
+rendering.
+-}
+type SummaryListItem msg
+    = SummaryListItem Properties (Options msg)
+
+
+type alias Properties =
+    { title : String
+    , caption : String
+    }
+
+
+type alias Options msg =
+    { selected : Bool
+    , badge : Maybe Badge
+    , checkbox : Maybe (Checkbox msg)
+    }
+
+
+{-| Constructs a summary by receiving its title and caption.
+
+    Summary.withItems
+        [ { id = 0, name = "Catarina" }
+        , { id = 1, name = "Gabriel" }
+        ]
+        someListView
+
+-}
+summaryListItem : String -> String -> SummaryListItem msg
+summaryListItem title caption =
+    SummaryListItem (Properties title caption) (Options False Nothing Nothing)
+
+
+{-| Indicates whether the summary is selected or not.
+
+    Summary.withSelected True
+        someListView
+
+-}
+withSelected : Bool -> SummaryListItem msg -> SummaryListItem msg
+withSelected selected (SummaryListItem prop opt) =
+    SummaryListItem prop { opt | selected = selected }
+
+
+{-| Adds a badge to the right side of the summary.
+
+    Summary.withBadge someBadge
+        someListView
+
+-}
+withBadge : Badge -> SummaryListItem msg -> SummaryListItem msg
+withBadge badge (SummaryListItem prop opt) =
+    SummaryListItem prop { opt | badge = Just badge }
+
+
+{-| Adds a checkbox to the left side of the summary.
+
+    Summary.withCheckbox someCheckbox
+        someListView
+
+-}
+withCheckbox : Checkbox msg -> SummaryListItem msg -> SummaryListItem msg
+withCheckbox checkbox (SummaryListItem prop opt) =
+    SummaryListItem prop { opt | checkbox = Just checkbox }
+
+
+{-| End of the builder's life.
+The result of this function is a ready-to-insert Elm UI's Element.
+-}
+renderElement : RenderConfig -> SummaryListItem msg -> Element msg
+renderElement renderConfig (SummaryListItem { title, caption } opt) =
+    let
+        colors =
+            listItemColors opt
+
+        label =
+            ( "label", listItemLabel renderConfig colors title caption )
+
+        maybeBadge =
+            case opt.badge of
+                Just badge ->
+                    Just ( "badge", listItemBadge renderConfig <| colors.badge badge )
+
+                Nothing ->
+                    Nothing
+
+        maybeCheckbox =
+            case opt.checkbox of
+                Just checkbox ->
+                    Just ( "checkbox", listItemCheckbox renderConfig checkbox )
+
+                Nothing ->
+                    Nothing
+    in
+    Keyed.row
+        [ Element.width fill
+        , Element.paddingEach { top = 11, bottom = 11, left = 15, right = 12 }
+        ]
+        (maybeBadge
+            |> Maybe.map List.singleton
+            |> Maybe.withDefault []
+            |> (::) label
+            |> prependMaybe maybeCheckbox
+        )
+
+
+
+-- Internal
+
+
+type alias ColorsHelper =
+    { badge : Badge -> Badge
+    , title : Palette.Color
+    , caption : Palette.Color
+    }
+
+
+listItemLabel : RenderConfig -> ColorsHelper -> String -> String -> Element msg
+listItemLabel renderConfig colors title caption =
+    Keyed.column
+        [ Element.width fill, Element.clipX, Element.spacing 4 ]
+        [ ( "title", listItemTitle renderConfig colors.title title )
+        , ( "caption", listItemCaption renderConfig colors.caption caption )
+        ]
+
+
+listItemBadge : RenderConfig -> Badge -> Element msg
+listItemBadge renderConfig badge =
+    badge
+        |> Badge.renderElement renderConfig
+        |> Element.el [ Element.alignTop ]
+
+
+listItemTitle : RenderConfig -> Palette.Color -> String -> Element msg
+listItemTitle renderConfig color title =
+    Text.body1 title
+        |> Text.withOverflow ellipsize
+        |> Text.withColor color
+        |> Text.renderElement renderConfig
+        |> Element.el [ Element.width fill ]
+
+
+listItemCaption : RenderConfig -> Palette.Color -> String -> Element msg
+listItemCaption renderConfig color caption =
+    Text.caption caption
+        |> Text.withOverflow ellipsize
+        |> Text.withColor color
+        |> Text.renderElement renderConfig
+
+
+listItemColors : Options msg -> ColorsHelper
+listItemColors { selected, checkbox } =
+    let
+        defaultColors =
+            { badge = identity
+            , title =
+                Palette.color tonePrimary brightnessLighter
+                    |> Palette.setContrasting True
+            , caption = Palette.color toneGray brightnessMiddle
+            }
+    in
+    if selected then
+        case checkbox of
+            Just _ ->
+                defaultColors
+
+            Nothing ->
+                { badge = Badge.withTone Badge.primaryDark
+                , title =
+                    Palette.color tonePrimary brightnessMiddle
+                        |> Palette.setContrasting True
+                , caption = Palette.color tonePrimary brightnessLight
+                }
+
+    else
+        defaultColors
+
+
+listItemCheckbox : RenderConfig -> Checkbox msg -> Element msg
+listItemCheckbox renderConfig checkbox =
+    checkbox
+        |> Checkbox.renderElement renderConfig
+        |> Element.el [ Element.alignTop ]


### PR DESCRIPTION
#### :thinking: What?

- Add `UI.ListView.SummaryItem`:
  - roughly the same as `UI.SummaryListItem` but using "with pattern"
  - optional badge using `withBadge`
  - optional checkbox using `withCheckbox`
  - consistent with [Figma](https://www.figma.com/file/DTyoSveNksHpZCdU8a7BNs/Dashboard?node-id=1813%3A96)
- Add `UI.ListView.simpleList`:
  - basically the same as `UI.ListView.selectList` but without built-in selection
  - no visual changes
- Update `Layouts.Stories` to use `UI.ListView.SummaryItem`

#### 👀 Results

- When not using checkbox:

![image](https://user-images.githubusercontent.com/2013206/112215510-365e4080-8bff-11eb-9d26-9b894469148a.png)

- When using checkbox and removing selection's background:

![image](https://user-images.githubusercontent.com/2013206/112215738-7b827280-8bff-11eb-8f5c-872d85c35074.png)

#### :man_shrugging: Why?

- [Figma](https://www.figma.com/file/DTyoSveNksHpZCdU8a7BNs/Dashboard?node-id=1813%3A74)
  - changes `UI.SummaryListItem` paddings
  - adds checkboxes to `UI.SummaryListItem`, and that would introduce breaking changes without using "with pattern"

#### :pushpin: Jira Issue

[WMS-802](https://paacklogistics.atlassian.net/browse/WMS-802)
