### PR TITLE
WMS-916 | SummaryItem tone, icon and bullet icon

### DIFF
--- a/src/UI/ListView/SummaryItem.elm
+++ b/src/UI/ListView/SummaryItem.elm
@@ -1,6 +1,6 @@
 module UI.ListView.SummaryItem exposing
     ( SummaryItem, summaryItem
-    , withSelected, withBadge, withCheckbox
+    , withSelected, withBadge, withCheckbox, withIcon, withBulletIcon, withBackgroundTone
     , renderElement
     )
 
@@ -32,7 +32,7 @@ This component is meant to be used with [`ListView`](UI-ListView).
 
 # Options
 
-@docs withSelected, withBadge, withCheckbox
+@docs withSelected, withBadge, withCheckbox, withIcon, withBulletIcon, withBackgroundTone
 
 
 # Rendering
@@ -41,10 +41,13 @@ This component is meant to be used with [`ListView`](UI-ListView).
 
 -}
 
-import Element exposing (Element, fill)
+import Element exposing (Element, fill, px)
+import Element.Background as Background
+import Element.Border as Border
 import Element.Keyed as Keyed
 import UI.Badge as Badge exposing (Badge)
 import UI.Checkbox as Checkbox exposing (Checkbox)
+import UI.Icon as Icon exposing (Icon)
 import UI.Internal.Basics exposing (prependMaybe)
 import UI.Palette as Palette
     exposing
@@ -55,6 +58,7 @@ import UI.Palette as Palette
         , tonePrimary
         )
 import UI.RenderConfig exposing (RenderConfig)
+import UI.Size as Size
 import UI.Text as Text exposing (ellipsize)
 
 
@@ -79,6 +83,9 @@ type alias Options msg =
     { selected : Bool
     , badge : Maybe Badge
     , checkbox : Maybe (Checkbox msg)
+    , bullet : Maybe Icon
+    , icon : Maybe Icon
+    , backgroundTone : Maybe Palette.Tone
     }
 
 
@@ -89,7 +96,9 @@ type alias Options msg =
 -}
 summaryItem : String -> String -> SummaryItem msg
 summaryItem title caption =
-    SummaryItem (Properties title caption) (Options False Nothing Nothing)
+    SummaryItem
+        (Properties title caption)
+        (Options False Nothing Nothing Nothing Nothing Nothing)
 
 
 {-| Indicates whether the summary is selected or not.
@@ -101,6 +110,39 @@ summaryItem title caption =
 withSelected : Bool -> SummaryItem msg -> SummaryItem msg
 withSelected selected (SummaryItem prop opt) =
     SummaryItem prop { opt | selected = selected }
+
+
+{-| Adds an icon to the right side of the summary.
+
+    Summary.withIcon (Icon.fix "Problem Solving")
+        someListView
+
+-}
+withIcon : Icon -> SummaryItem msg -> SummaryItem msg
+withIcon icon (SummaryItem prop opt) =
+    SummaryItem prop { opt | icon = Just icon }
+
+
+{-| Adds an icon to the left side of the summary.
+
+    Summary.withBulletIcon (Icon.fixIssues "Problem Solving")
+        someListView
+
+-}
+withBulletIcon : Icon -> SummaryItem msg -> SummaryItem msg
+withBulletIcon icon (SummaryItem prop opt) =
+    SummaryItem prop { opt | bullet = Just icon }
+
+
+{-| Applies a tone to summary's background.
+
+    Summary.withBackgroundTone Palette.toneWarning
+        someListView
+
+-}
+withBackgroundTone : Palette.Tone -> SummaryItem msg -> SummaryItem msg
+withBackgroundTone tone (SummaryItem prop opt) =
+    SummaryItem prop { opt | backgroundTone = Just tone }
 
 
 {-| Adds a badge to the right side of the summary.
@@ -133,36 +175,26 @@ renderElement renderConfig (SummaryItem { title, caption } opt) =
     let
         colors =
             listItemColors opt
-
-        label =
-            ( "label", listItemLabel renderConfig colors title caption )
-
-        maybeBadge =
-            case opt.badge of
-                Just badge ->
-                    Just ( "badge", listItemBadge renderConfig <| colors.badge badge )
-
-                Nothing ->
-                    Nothing
-
-        maybeCheckbox =
-            case opt.checkbox of
-                Just checkbox ->
-                    Just ( "checkbox", listItemCheckbox renderConfig checkbox )
-
-                Nothing ->
-                    Nothing
     in
-    Keyed.row
-        [ Element.width fill
-        , Element.paddingEach { top = 11, bottom = 11, left = 15, right = 12 }
-        ]
-        (maybeBadge
-            |> Maybe.map List.singleton
-            |> Maybe.withDefault []
-            |> (::) label
-            |> prependMaybe maybeCheckbox
-        )
+    opt.badge
+        |> Maybe.map
+            (colors.badge >> listItemBadge renderConfig >> List.singleton)
+        |> Maybe.withDefault []
+        |> prependMaybe
+            (Maybe.map (listItemIcon renderConfig) opt.icon)
+        |> (::)
+            (listItemLabel renderConfig colors title caption)
+        |> prependMaybe
+            (Maybe.map (listItemBullet renderConfig colors.tone opt.selected) opt.bullet)
+        |> prependMaybe
+            (Maybe.map (listItemCheckbox renderConfig) opt.checkbox)
+        |> Keyed.row
+            (Element.width fill
+                :: Element.paddingEach { top = 11, bottom = 11, left = 15, right = 12 }
+                :: (Maybe.withDefault [] <|
+                        Maybe.map (backgroundColor >> List.singleton) opt.backgroundTone
+                   )
+            )
 
 
 
@@ -173,44 +205,19 @@ type alias ColorsHelper =
     { badge : Badge -> Badge
     , title : Palette.Color
     , caption : Palette.Color
+    , tone : Palette.Tone
     }
 
 
-listItemLabel : RenderConfig -> ColorsHelper -> String -> String -> Element msg
-listItemLabel renderConfig colors title caption =
-    Keyed.column
-        [ Element.width fill, Element.clipX, Element.spacing 4 ]
-        [ ( "title", listItemTitle renderConfig colors.title title )
-        , ( "caption", listItemCaption renderConfig colors.caption caption )
-        ]
-
-
-listItemBadge : RenderConfig -> Badge -> Element msg
-listItemBadge renderConfig badge =
-    badge
-        |> Badge.renderElement renderConfig
-        |> Element.el [ Element.alignTop ]
-
-
-listItemTitle : RenderConfig -> Palette.Color -> String -> Element msg
-listItemTitle renderConfig color title =
-    Text.body1 title
-        |> Text.withOverflow ellipsize
-        |> Text.withColor color
-        |> Text.renderElement renderConfig
-        |> Element.el [ Element.width fill ]
-
-
-listItemCaption : RenderConfig -> Palette.Color -> String -> Element msg
-listItemCaption renderConfig color caption =
-    Text.caption caption
-        |> Text.withOverflow ellipsize
-        |> Text.withColor color
-        |> Text.renderElement renderConfig
+backgroundColor : Palette.Tone -> Element.Attr decorative msg
+backgroundColor tone =
+    Palette.color tone Palette.brightnessLight4
+        |> Palette.toElementColor
+        |> Background.color
 
 
 listItemColors : Options msg -> ColorsHelper
-listItemColors { selected, checkbox } =
+listItemColors opt =
     let
         defaultColors =
             { badge = identity
@@ -218,10 +225,11 @@ listItemColors { selected, checkbox } =
                 Palette.color tonePrimary brightnessLighter
                     |> Palette.setContrasting True
             , caption = Palette.color toneGray brightnessMiddle
+            , tone = tonePrimary
             }
     in
-    if selected then
-        case checkbox of
+    if opt.selected then
+        case opt.checkbox of
             Just _ ->
                 defaultColors
 
@@ -231,14 +239,108 @@ listItemColors { selected, checkbox } =
                     Palette.color tonePrimary brightnessMiddle
                         |> Palette.setContrasting True
                 , caption = Palette.color tonePrimary brightnessLight
+                , tone = tonePrimary
                 }
 
     else
-        defaultColors
+        { defaultColors | tone = Maybe.withDefault tonePrimary opt.backgroundTone }
 
 
-listItemCheckbox : RenderConfig -> Checkbox msg -> Element msg
+listItemCheckbox : RenderConfig -> Checkbox msg -> ( String, Element msg )
 listItemCheckbox renderConfig checkbox =
     checkbox
         |> Checkbox.renderElement renderConfig
         |> Element.el [ Element.alignTop ]
+        |> Tuple.pair "checkbox"
+
+
+listItemBullet : RenderConfig -> Palette.Tone -> Bool -> Icon -> ( String, Element msg )
+listItemBullet renderConfig tone isSelected icon =
+    icon
+        |> Icon.withCustomSize 11
+        |> Icon.withColor (Palette.color tone Palette.brightnessDarkest)
+        |> Icon.renderElement renderConfig
+        |> Element.el
+            [ Element.centerY
+            , Element.centerX
+            ]
+        |> Element.el
+            [ Element.width (px 20)
+            , Element.height (px 20)
+            , Border.rounded 10
+            , Palette.color tone (brightness isSelected)
+                |> Palette.toElementColor
+                |> Background.color
+            ]
+        |> Element.el
+            [ Element.alignTop
+            , Element.paddingEach { top = 0, right = 8, bottom = 0, left = 0 }
+            ]
+        |> Tuple.pair "bullet"
+
+
+brightness : Bool -> Palette.Brightness
+brightness isSelected =
+    if isSelected then
+        Palette.brightnessLighter
+
+    else
+        Palette.brightnessLight
+
+
+listItemLabel :
+    RenderConfig
+    -> ColorsHelper
+    -> String
+    -> String
+    -> ( String, Element msg )
+listItemLabel renderConfig colors title caption =
+    ( "label"
+    , Keyed.column
+        [ Element.width fill, Element.clipX, Element.spacing 4 ]
+        [ listItemTitle renderConfig colors.title title
+        , listItemCaption renderConfig colors.caption caption
+        ]
+    )
+
+
+listItemTitle : RenderConfig -> Palette.Color -> String -> ( String, Element msg )
+listItemTitle renderConfig color title =
+    Text.subtitle1 title
+        |> Text.withOverflow ellipsize
+        |> Text.withColor color
+        |> Text.renderElement renderConfig
+        |> Tuple.pair "text"
+        |> Keyed.el [ Element.width fill ]
+        |> Tuple.pair "title"
+
+
+listItemCaption : RenderConfig -> Palette.Color -> String -> ( String, Element msg )
+listItemCaption renderConfig color caption =
+    Text.caption caption
+        |> Text.withOverflow ellipsize
+        |> Text.withColor color
+        |> Text.renderElement renderConfig
+        |> Tuple.pair "caption"
+
+
+listItemIcon : RenderConfig -> Icon -> ( String, Element msg )
+listItemIcon renderConfig icon =
+    icon
+        |> Icon.withSize Size.extraSmall
+        |> Icon.renderElement renderConfig
+        |> Element.el
+            [ Element.alignTop
+            , Element.alignLeft
+            , Element.paddingEach
+                { left = 4, right = 4, top = 2, bottom = 0 }
+            ]
+        |> Tuple.pair "icon"
+
+
+listItemBadge : RenderConfig -> Badge -> ( String, Element msg )
+listItemBadge renderConfig badge =
+    badge
+        |> Badge.renderElement renderConfig
+        |> Element.el [ Element.alignTop ]
+        |> Tuple.pair "badge"


### PR DESCRIPTION
#### :thinking: What?

Adds the following features to `SummaryItem`:

- Entry tone using `withTone`
- Suffix icon using `withIcon`
- Bullet with icon using `withBulletIcon`

#### :man_shrugging: Why?

Required for problem-solving:

- [The red wrench icon:](https://www.figma.com/file/DTyoSveNksHpZCdU8a7BNs/Dashboard?node-id=2330%3A19005)

![image](https://user-images.githubusercontent.com/2013206/119570888-0bbb7000-bd87-11eb-8dd8-cea782b97533.png)

- [The background tone and yellow bullet with icon:](https://www.figma.com/file/DTyoSveNksHpZCdU8a7BNs/Dashboard?node-id=1813%3A191)

![image](https://user-images.githubusercontent.com/2013206/119570892-0d853380-bd87-11eb-949f-d93aa1d07e4b.png)

#### 🔍 How it looks?

![image](https://user-images.githubusercontent.com/2013206/119585834-ea1bb200-bda1-11eb-9bdc-146dddecfc15.png)

![image](https://user-images.githubusercontent.com/2013206/119585718-a3c65300-bda1-11eb-8ec7-f91dc3f6468b.png)

#### :pushpin: Jira Issue

[WMS-916](https://paacklogistics.atlassian.net/browse/WMS-916)

#### :no_good: Blocked by

- [ ] https://github.com/PaackEng/paack-ui/pull/226
 
### :fire: Extra

Spent some extra time trying to properly align that suffix icon, but couldn't without resorting to some ugly hacks including hardcoded sizes. I really think we should ignore that for now and try to align it later...