### PR TITLE
Fix header

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",

--- a/src/UI/ListView.elm
+++ b/src/UI/ListView.elm
@@ -687,13 +687,22 @@ headerView cfg opt =
                 ]
                 [ Text.heading5 header
                     |> Text.renderElement cfg
-                    |> Element.el [ Element.width shrink ]
+                    |> Element.el [ Element.width <| headerWidth opt ]
                 , headerBadge cfg opt
                 , dropdown cfg opt.dropdown
                 ]
 
         Nothing ->
             Element.none
+
+headerWidth : Options object msg -> Element.Length
+headerWidth opt =
+    case opt.headerBadge of
+        Just _ ->
+            shrink
+
+        Nothing ->
+            fill
 
 
 dropdown : RenderConfig -> Maybe (Dropdown msg) -> Element msg

--- a/src/UI/ListView.elm
+++ b/src/UI/ListView.elm
@@ -695,6 +695,7 @@ headerView cfg opt =
         Nothing ->
             Element.none
 
+
 headerWidth : Options object msg -> Element.Length
 headerWidth opt =
     case opt.headerBadge of


### PR DESCRIPTION
#### :thinking: What?

Fix header width bug that is making the header render one word per line.

#### :man_shrugging: Why?

The header badge feature introduced along with `3.5.0` changed `Element.width fill` to `Element.width shrink`, this is causing the header to render one word per line. 

![image](https://user-images.githubusercontent.com/2013206/121097333-36b3b400-c7ca-11eb-908e-5eafce682e8b.png)

This temporary fix should be enough to maintain current styling in pages that aren't using header badges.

