### PR TITLE
Revert: elm-bump CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,6 @@ jobs:
           elm-working-directory: 'showcase'
           elm-review-extra-options: --ignore-dirs '../src'
 
-      - name: Don't forget to bump
-        run: bash -c "! echo 'n' | yarn exec elm bump | grep update"
-
   tests:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
#### :thinking: What?

Removes the experimental elm-bump CI

#### :man_shrugging: Why?

It was triggering even when no elm files changed.

#### :pushpin: Jira Issue

Not tracked.

#### :no_good: Blocked by

Nothing.

#### :clipboard: Pending

It'll be back, I'll elaborate a better script...
