### PR TITLE
Fix radio button

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",

--- a/showcase/src/Main.elm
+++ b/showcase/src/Main.elm
@@ -175,8 +175,7 @@ updateStories msg ({ customModel } as model) =
 
         RadioStoriesMsg subMsg ->
             Radio.update subMsg customModel.radioStories
-                |> R.map (\t -> { customModel | radioStories = t })
-                |> finishCustomUpdate model
+                |> R.map (\t -> { model | customModel = { customModel | radioStories = t } })
 
         TabsStoriesMsg subMsg ->
             Tabs.update subMsg customModel.tabsStories

--- a/showcase/src/Radio/Msg.elm
+++ b/showcase/src/Radio/Msg.elm
@@ -1,8 +1,10 @@
 module Radio.Msg exposing (Msg(..))
 
+import Browser.Dom as Dom
 import Radio.Model as Model
 
 
 type Msg
-    = Set Model.Options
-    | NoOp Model.Options
+    = Set String Model.Options
+    | FocusResult (Result Dom.Error ())
+    | NoOp

--- a/showcase/src/Radio/Stories.elm
+++ b/showcase/src/Radio/Stories.elm
@@ -1,6 +1,5 @@
 module Radio.Stories exposing (stories, update)
 
-import Browser.Dom as Dom
 import Element exposing (Element)
 import Model exposing (Model)
 import Msg exposing (Msg)
@@ -8,7 +7,6 @@ import PluginOptions exposing (defaultWithMenu)
 import Radio.Model as RadioModel exposing (Options)
 import Radio.Msg as RadioMsg
 import Return exposing (Return)
-import Task
 import UI.Effect as Effect
 import UI.Radio as Radio
 import UI.RenderConfig exposing (RenderConfig)

--- a/showcase/src/Radio/Stories.elm
+++ b/showcase/src/Radio/Stories.elm
@@ -1,5 +1,6 @@
 module Radio.Stories exposing (stories, update)
 
+import Browser.Dom as Dom
 import Element exposing (Element)
 import Model exposing (Model)
 import Msg exposing (Msg)
@@ -7,6 +8,8 @@ import PluginOptions exposing (defaultWithMenu)
 import Radio.Model as RadioModel exposing (Options)
 import Radio.Msg as RadioMsg
 import Return exposing (Return)
+import Task
+import UI.Effect as Effect
 import UI.Radio as Radio
 import UI.RenderConfig exposing (RenderConfig)
 import UIExplorer exposing (storiesOf)
@@ -22,13 +25,19 @@ import Utils
         )
 
 
-update : RadioMsg.Msg -> RadioModel.Model -> Return RadioMsg.Msg RadioModel.Model
+update : RadioMsg.Msg -> RadioModel.Model -> Return Msg.Msg RadioModel.Model
 update msg model =
     case msg of
-        RadioMsg.Set newValue ->
-            ( { model | selected = Just newValue }, Cmd.none )
+        RadioMsg.Set id newValue ->
+            ( { model | selected = Just newValue }
+            , Effect.domFocus (RadioMsg.FocusResult >> Msg.RadioStoriesMsg) id
+                |> Effect.perform
+            )
 
-        RadioMsg.NoOp _ ->
+        RadioMsg.FocusResult _ ->
+            ( model, Cmd.none )
+
+        RadioMsg.NoOp ->
             ( model, Cmd.none )
 
 
@@ -95,10 +104,10 @@ label =
 
 view : Radio.Direction -> Radio.RadioSize -> RenderConfig -> Model -> Element Msg
 view direction size renderConfig { radioStories } =
-    radioGroupView direction size renderConfig (RadioMsg.Set >> Msg.RadioStoriesMsg) radioStories
+    radioGroupView direction size renderConfig (\id value -> Msg.RadioStoriesMsg <| RadioMsg.Set id value) radioStories
 
 
-radioGroupView : Radio.Direction -> Radio.RadioSize -> RenderConfig -> (Options -> msg) -> RadioModel.Model -> Element msg
+radioGroupView : Radio.Direction -> Radio.RadioSize -> RenderConfig -> (String -> Options -> msg) -> RadioModel.Model -> Element msg
 radioGroupView direction size renderConfig msg { selected } =
     Element.column
         [ Element.spacing 8 ]
@@ -124,9 +133,9 @@ unitedView : RenderConfig -> Element Msg
 unitedView renderConfig =
     Element.column
         [ Element.spacing 8 ]
-        [ radioGroupView Radio.vertical Radio.sizeSM renderConfig (RadioMsg.NoOp >> Msg.RadioStoriesMsg) { selected = Nothing }
-        , radioGroupView Radio.horizontal Radio.sizeSM renderConfig (RadioMsg.NoOp >> Msg.RadioStoriesMsg) { selected = Nothing }
-        , radioGroupView Radio.vertical Radio.sizeMD renderConfig (RadioMsg.NoOp >> Msg.RadioStoriesMsg) { selected = Nothing }
+        [ radioGroupView Radio.vertical Radio.sizeSM renderConfig (\_ _ -> Msg.RadioStoriesMsg RadioMsg.NoOp) { selected = Nothing }
+        , radioGroupView Radio.horizontal Radio.sizeSM renderConfig (\_ _ -> Msg.RadioStoriesMsg RadioMsg.NoOp) { selected = Nothing }
+        , radioGroupView Radio.vertical Radio.sizeMD renderConfig (\_ _ -> Msg.RadioStoriesMsg RadioMsg.NoOp) { selected = Nothing }
         ]
 
 

--- a/showcase/src/Radio/Stories.elm
+++ b/showcase/src/Radio/Stories.elm
@@ -111,8 +111,10 @@ radioGroupView direction size renderConfig msg { selected } =
         [ Element.spacing 8 ]
         [ iconsSvgSprite
         , Radio.group
-            label
-            msg
+            { label = label
+            , onSelectMsg = msg
+            , idPrefix = "band-radio"
+            }
             |> Radio.withSelected selected
             |> Radio.withDirection direction
             |> Radio.withSize size
@@ -141,8 +143,10 @@ codeForVerticalRadioGroup : String
 codeForVerticalRadioGroup =
     prettifyElmCode """
 Radio.group
-    "Pick one classic rock band"
-    Msg.RadioSet
+    { label = "Pick one classic rock band"
+    , onSelectMsg = Msg.RadioSet
+    , idPrefix = "band-radio"
+    }
     |> Radio.withSelected model.selected
     |> Radio.withButtons
         [ Radio.button Model.Queen "Queen"
@@ -159,8 +163,10 @@ codeForHorizontalRadioGroup : String
 codeForHorizontalRadioGroup =
     prettifyElmCode """
 Radio.group
-    "Pick one classic rock band"
-    Msg.RadioSet
+    { label = "Pick one classic rock band"
+    , onSelectMsg = Msg.RadioSet
+    , idPrefix = "band-radio"
+    }
     |> Radio.withSelected model.selected
     |> Radio.withDirection model.direction
     |> Radio.withButtons

--- a/src/UI/Checkbox.elm
+++ b/src/UI/Checkbox.elm
@@ -179,7 +179,7 @@ renderElement renderConfig (Checkbox { message, label, state } options) =
 
         checkboxAttrs =
             if options.labelVisible then
-                SelectionControl.buttonAttributes size state
+                SelectionControl.buttonAttributes size
 
             else
                 []

--- a/src/UI/Checkbox.elm
+++ b/src/UI/Checkbox.elm
@@ -179,7 +179,7 @@ renderElement renderConfig (Checkbox { message, label, state } options) =
 
         checkboxAttrs =
             if options.labelVisible then
-                SelectionControl.buttonAttributes size
+                SelectionControl.buttonAttributes size state
 
             else
                 []

--- a/src/UI/Effect.elm
+++ b/src/UI/Effect.elm
@@ -1,6 +1,7 @@
 module UI.Effect exposing
     ( Effect, SideEffect(..), none, batch, msgToCmd, analytics
     , map, perform
+    , domFocus
     )
 
 {-| `UI.Effect` is a combination of every command required for `paack-ui` to work correctly.
@@ -91,6 +92,13 @@ msgToCmd msg =
 analytics : Analytics -> Effect msg
 analytics analytics_ =
     [ Analytics analytics_ ]
+
+
+{-| The dom focus effect constructor.
+-}
+domFocus : (Result Dom.Error () -> msg) -> String -> Effect msg
+domFocus msg id =
+    [ DomFocus msg id ]
 
 
 {-| Perform a minimal interpretation of side-effects into commands.

--- a/src/UI/Effect.elm
+++ b/src/UI/Effect.elm
@@ -1,7 +1,6 @@
 module UI.Effect exposing
-    ( Effect, SideEffect(..), none, batch, msgToCmd, analytics
+    ( Effect, SideEffect(..), none, batch, msgToCmd, analytics, domFocus
     , map, perform
-    , domFocus
     )
 
 {-| `UI.Effect` is a combination of every command required for `paack-ui` to work correctly.
@@ -19,7 +18,7 @@ they fit in real applications.
 
 # Create
 
-@docs Effect, SideEffect, none, batch, msgToCmd, analytics
+@docs Effect, SideEffect, none, batch, msgToCmd, analytics, domFocus
 
 
 # Transform

--- a/src/UI/Internal/SelectionControl.elm
+++ b/src/UI/Internal/SelectionControl.elm
@@ -35,21 +35,14 @@ sizes size =
             Sizes 28 10 3
 
 
-buttonAttributes : SelectionControlSize -> Bool -> List (Element.Attribute msg)
-buttonAttributes size state =
+buttonAttributes : SelectionControlSize -> List (Element.Attribute msg)
+buttonAttributes size =
     [ Element.spacing 10
     , Element.width shrink
     , Element.padding <| .padding <| sizes size
     , Element.pointer
     , Border.rounded 6
     , Element.mouseOver [ Background.color <| Colors.gray.light3 ]
-    , Element.htmlAttribute <|
-        HtmlAttrs.tabindex <|
-            if state then
-                0
-
-            else
-                -1
     , Element.focused
         [ Border.innerShadow
             { offset = ( 0, 0 )

--- a/src/UI/Internal/SelectionControl.elm
+++ b/src/UI/Internal/SelectionControl.elm
@@ -35,15 +35,21 @@ sizes size =
             Sizes 28 10 3
 
 
-buttonAttributes : SelectionControlSize -> List (Element.Attribute msg)
-buttonAttributes size =
+buttonAttributes : SelectionControlSize -> Bool -> List (Element.Attribute msg)
+buttonAttributes size state =
     [ Element.spacing 10
     , Element.width shrink
     , Element.padding <| .padding <| sizes size
     , Element.pointer
     , Border.rounded 6
     , Element.mouseOver [ Background.color <| Colors.gray.light3 ]
-    , Element.htmlAttribute <| HtmlAttrs.tabindex 0
+    , Element.htmlAttribute <|
+        HtmlAttrs.tabindex <|
+            if state then
+                0
+
+            else
+                -1
     , Element.focused
         [ Border.innerShadow
             { offset = ( 0, 0 )

--- a/src/UI/Internal/SelectionControl.elm
+++ b/src/UI/Internal/SelectionControl.elm
@@ -3,7 +3,6 @@ module UI.Internal.SelectionControl exposing (..)
 import Element exposing (Attribute, px, shrink)
 import Element.Background as Background
 import Element.Border as Border
-import Html.Attributes as HtmlAttrs
 import UI.Internal.Colors as Colors
 
 

--- a/src/UI/Internal/SelectionControl.elm
+++ b/src/UI/Internal/SelectionControl.elm
@@ -55,7 +55,7 @@ buttonAttributes size state =
             { offset = ( 0, 0 )
             , size = 2
             , blur = 0
-            , color = Colors.primary.middle
+            , color = Colors.primary.light1
             }
         ]
     ]

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -478,8 +478,10 @@ selectFilterRender :
     -> Element msg
 selectFilterRender renderConfig { fromFiltersMsg, index } list { current, applied } =
     Radio.group
-        (renderConfig |> localeTerms >> .filters >> .select >> .description)
-        (\_ subIndex -> fromFiltersMsg <| Filters.EditSelect { column = index, value = subIndex })
+        { label = renderConfig |> localeTerms >> .filters >> .select >> .description
+        , onSelectMsg = \_ subIndex -> fromFiltersMsg <| Filters.EditSelect { column = index, value = subIndex }
+        , idPrefix = "table-select-filter"
+        }
         |> Radio.withSelected (maybeNotThen applied current)
         |> Radio.withButtons (List.indexedMap Radio.button list)
         |> Radio.withWidth Radio.widthFull
@@ -584,8 +586,10 @@ periodDateFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } ed
             |> TextField.renderElement renderConfig
             |> internalPaddingBox
         , Radio.group
-            filtersTerms.period.description
-            editComparisonMsg
+            { label = filtersTerms.period.description
+            , onSelectMsg = editComparisonMsg
+            , idPrefix = "table-date-period-filter"
+            }
             |> Radio.withSelected (Just current.comparison)
             |> Radio.withButtons options
             |> Radio.withWidth Radio.widthFull

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -479,7 +479,7 @@ selectFilterRender :
 selectFilterRender renderConfig { fromFiltersMsg, index } list { current, applied } =
     Radio.group
         (renderConfig |> localeTerms >> .filters >> .select >> .description)
-        (\subIndex -> fromFiltersMsg <| Filters.EditSelect { column = index, value = subIndex })
+        (\_ subIndex -> fromFiltersMsg <| Filters.EditSelect { column = index, value = subIndex })
         |> Radio.withSelected (maybeNotThen applied current)
         |> Radio.withButtons (List.indexedMap Radio.button list)
         |> Radio.withWidth Radio.widthFull
@@ -560,7 +560,7 @@ periodDateFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } ed
         editDateMsg str =
             fromFiltersMsg <| Filters.EditPeriodDate { column = index, value = str }
 
-        editComparisonMsg value =
+        editComparisonMsg _ value =
             fromFiltersMsg <| Filters.EditPeriodComparison { column = index, value = value }
 
         current =

--- a/src/UI/Radio.elm
+++ b/src/UI/Radio.elm
@@ -341,9 +341,21 @@ renderButton renderConfig (RadioSize size) index (RadioButton _ label) state =
 
             else
                 Element.none
+
+        buttonAttributes =
+            (Element.htmlAttribute <|
+                HtmlAttrs.tabindex <|
+                    if isSelected then
+                        0
+
+                    else
+                        -1
+            )
+                :: Utils.id (makeId index label)
+                :: SelectionControl.buttonAttributes size
     in
     Element.row
-        (Utils.id (makeId index label) :: SelectionControl.buttonAttributes size isSelected)
+        buttonAttributes
         [ Element.el radioAttrs radioBulletContent
         , Text.body1 label |> Text.renderElement renderConfig
         ]

--- a/src/UI/Radio.elm
+++ b/src/UI/Radio.elm
@@ -11,8 +11,10 @@ module UI.Radio exposing
 {-| Accessible and uniform-styled implementation of a radio buttons.
 
     Radio.group
-        "Pick a favorite animal:"
-        Msg.SelectRadio
+        { label = "Pick a favorite animal:"
+        , onSelectMsg = Msg.SelectRadio
+        , idPrefix = "radio-animal"
+        }
         |> Radio.withSelected (Just Model.Felines)
         |> Radio.withButtons
             [ Radio.button Model.Felines "Felines"

--- a/src/UI/Radio.elm
+++ b/src/UI/Radio.elm
@@ -319,7 +319,7 @@ renderButton renderConfig (RadioSize size) label state =
             else
                 Element.none
     in
-    Element.row (SelectionControl.buttonAttributes size)
+    Element.row (SelectionControl.buttonAttributes size isSelected)
         [ Element.el radioAttrs radioBulletContent
         , Text.body1 label |> Text.renderElement renderConfig
         ]

--- a/src/UI/Radio.elm
+++ b/src/UI/Radio.elm
@@ -70,16 +70,16 @@ import UI.RenderConfig exposing (RenderConfig)
 import UI.Text as Text
 
 
-{-| The `RadioGroup id msg` type is used for describing the component for later rendering.
+{-| The `RadioGroup option msg` type is used for describing the component for later rendering.
 -}
-type RadioGroup id msg
-    = RadioGroup (Properties id msg) (Options id)
+type RadioGroup option msg
+    = RadioGroup (Properties option msg) (Options option)
 
 
-{-| The `RadioButton id` describes an individual radiobutton
+{-| The `RadioButton option` describes an individual radiobutton
 -}
-type RadioButton id
-    = RadioButton id String
+type RadioButton option
+    = RadioButton option String
 
 
 {-| Describes a compatible width.
@@ -102,15 +102,16 @@ type RadioSize
     = RadioSize SelectionControl.SelectionControlSize
 
 
-type alias Properties id msg =
+type alias Properties option msg =
     { label : String
-    , message : String -> id -> msg
+    , onSelectMsg : String -> option -> msg
+    , idPrefix : String
     }
 
 
-type alias Options id =
-    { selected : Maybe id
-    , buttons : List (RadioButton id)
+type alias Options option =
+    { selected : Maybe option
+    , buttons : List (RadioButton option)
     , width : RadioWidth
     , direction : Direction
     , size : RadioSize
@@ -125,9 +126,9 @@ The second is the message triggered when there is a selection.
         Radio.group "Pick a card" Msg.CardPicking
 
 -}
-group : String -> (String -> id -> msg) -> RadioGroup id msg
-group label message =
-    RadioGroup { label = label, message = message }
+group : Properties option msg -> RadioGroup option msg
+group props =
+    RadioGroup props
         { selected = Nothing
         , buttons = []
         , width = WidthRelative
@@ -141,9 +142,9 @@ group label message =
     Radio.button Model.OrangeJuice "Orange Juice"
 
 -}
-button : id -> String -> RadioButton id
-button id label =
-    RadioButton id label
+button : option -> String -> RadioButton option
+button option label =
+    RadioButton option label
 
 
 {-| Replaces a group's list of radio buttons.
@@ -156,7 +157,7 @@ button id label =
         someRadioGroup
 
 -}
-withButtons : List (RadioButton id) -> RadioGroup id msg -> RadioGroup id msg
+withButtons : List (RadioButton option) -> RadioGroup option msg -> RadioGroup option msg
 withButtons buttons (RadioGroup prop opt) =
     RadioGroup prop { opt | buttons = buttons }
 
@@ -166,7 +167,7 @@ withButtons buttons (RadioGroup prop opt) =
     Radio.withSelected (Just Model.DoubleCheddar)
 
 -}
-withSelected : Maybe id -> RadioGroup id msg -> RadioGroup id msg
+withSelected : Maybe option -> RadioGroup option msg -> RadioGroup option msg
 withSelected maybeSelected (RadioGroup prop opt) =
     RadioGroup prop { opt | selected = maybeSelected }
 
@@ -176,7 +177,7 @@ withSelected maybeSelected (RadioGroup prop opt) =
     Radio.withWidth Radio.widthFull someRadioGroup
 
 -}
-withWidth : RadioWidth -> RadioGroup id msg -> RadioGroup id msg
+withWidth : RadioWidth -> RadioGroup option msg -> RadioGroup option msg
 withWidth width (RadioGroup prop opt) =
     RadioGroup prop { opt | width = width }
 
@@ -186,7 +187,7 @@ withWidth width (RadioGroup prop opt) =
     Radio.withDirection Radio.horizontal someRadioGroup
 
 -}
-withDirection : Direction -> RadioGroup id msg -> RadioGroup id msg
+withDirection : Direction -> RadioGroup option msg -> RadioGroup option msg
 withDirection direction (RadioGroup prop opt) =
     RadioGroup prop { opt | direction = direction }
 
@@ -196,7 +197,7 @@ withDirection direction (RadioGroup prop opt) =
     Radio.withSize Radio.sizeMD someRadioGroup
 
 -}
-withSize : RadioSize -> RadioGroup id msg -> RadioGroup id msg
+withSize : RadioSize -> RadioGroup option msg -> RadioGroup option msg
 withSize size (RadioGroup prop opt) =
     RadioGroup prop { opt | size = size }
 
@@ -249,8 +250,8 @@ sizeMD =
 {-| End of the builder's life.
 The result of this function is a ready-to-insert Elm UI's Element.
 -}
-renderElement : RenderConfig -> RadioGroup id msg -> Element msg
-renderElement renderConfig (RadioGroup { label, message } { size, selected, buttons, width, direction }) =
+renderElement : RenderConfig -> RadioGroup option msg -> Element msg
+renderElement renderConfig (RadioGroup { label, onSelectMsg, idPrefix } { size, selected, buttons, width, direction }) =
     let
         radio =
             case direction of
@@ -261,7 +262,7 @@ renderElement renderConfig (RadioGroup { label, message } { size, selected, butt
                     Input.radioRow
     in
     radio [ widthToEl width ]
-        { onChange = \value -> message (findId value buttons) value
+        { onChange = \value -> onSelectMsg (findId idPrefix value buttons) value
         , selected = selected
         , label =
             Text.body2 label
@@ -277,27 +278,27 @@ renderElement renderConfig (RadioGroup { label, message } { size, selected, butt
                     ]
         , options =
             List.indexedMap
-                (\index ((RadioButton id _) as btn) ->
-                    Input.optionWith id (renderButton renderConfig size index btn)
+                (\index ((RadioButton option _) as btn) ->
+                    Input.optionWith
+                        option
+                        (renderButton renderConfig size (makeId idPrefix index) btn)
                 )
                 buttons
         }
 
 
-makeId : Int -> String -> String
-makeId index =
-    String.toLower
-        >> String.replace " " "-"
-        >> (++) ("radio-" ++ String.fromInt index ++ "-")
+makeId : String -> Int -> String
+makeId idPrefix index =
+    idPrefix ++ "-" ++ String.fromInt index
 
 
-findId : id -> List (RadioButton id) -> String
-findId id =
+findId : String -> option -> List (RadioButton option) -> String
+findId idPrefix value =
     List.indexedMap Tuple.pair
         >> List.foldl
-            (\( index, RadioButton id_ label ) acc ->
-                if id == id_ then
-                    Just <| makeId index label
+            (\( index, RadioButton option _ ) acc ->
+                if value == option then
+                    Just <| makeId idPrefix index
 
                 else
                     acc
@@ -316,8 +317,8 @@ optionStateToBool state =
             False
 
 
-renderButton : RenderConfig -> RadioSize -> Int -> RadioButton id -> Input.OptionState -> Element msg
-renderButton renderConfig (RadioSize size) index (RadioButton _ label) state =
+renderButton : RenderConfig -> RadioSize -> String -> RadioButton option -> Input.OptionState -> Element msg
+renderButton renderConfig (RadioSize size) id (RadioButton _ label) state =
     let
         isSelected =
             optionStateToBool state
@@ -351,7 +352,7 @@ renderButton renderConfig (RadioSize size) index (RadioButton _ label) state =
                     else
                         -1
             )
-                :: Utils.id (makeId index label)
+                :: Utils.id id
                 :: SelectionControl.buttonAttributes size
     in
     Element.row


### PR DESCRIPTION
#### :thinking: What?

- Add html ids to the radio buttons
- Update the messaging to send the id when selecting an option
- Update stories to handle the id and focus on the button 

#### :man_shrugging: Why?

Because the focus was not following the selection

#### :pushpin: Jira Issue

[DES-106](https://paacklogistics.atlassian.net/browse/DES-106)

#### :no_good: Blocked by

Nothing.

#### :clipboard: Pending

- [ ] Feed the trolls.

### :fire: Extra

Not happy at all having to break again the API and also the fact that the burden of focusing on the element lies on who's using it. I'm also not happy having to "generate" an id on the spot, although it should be reliable considering no one should have options with the same label. Any alternatives will be considered, these are some of them:
- Creating a `Radio.update : Radio.Msg -> (RadioState, Effect msg)` and returning a focus effect
- Creating a new entry point of the component as an alternative to `Radio.group` so that we at least avoid breaking the API
- A separate optional msg to handle the id when selecting (not sure how to do this though)
- Use real inputs and labels instead of the elm-ui implementation

To me this seems like [yet another](https://github.com/mdgriffith/elm-ui/issues/318) bug with elm-ui's radio: if the options are focusable it doesn't make for the focus not to follow the selection.
