### PR TITLE
LMO-515 | DES-111 | Prepare reusable Filter component (Internals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ For including these assets, we recommend using parcel.
 First, add `paack-ui-assets` using `npm install`.
 Secondly, add `import 'paack-ui-assets/js/paackSvgIconSprite.js';` to `index.js`
 
+You also have to import/provide "Fira Sans" font family, with the following weights: 400, 500, 600 and 700.
+
 ## Where to begin?
 
 See [the `UI.NavigationContainer` module documentation](http://package.elm-lang.org/packages/PaackEng/paack-ui/latest/UI-NavigationContainer) for the top-level component.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,14 @@ For including these assets, we recommend using parcel.
 First, add `paack-ui-assets` using `npm install`.
 Secondly, add `import 'paack-ui-assets/js/paackSvgIconSprite.js';` to `index.js`
 
-You also have to import/provide "Fira Sans" font family, with the following weights: 400, 500, 600 and 700.
+Also, you have to import or provide the "Fira Sans" font family, with the following weights: 400, 500, 600 and 700. Here's an example for you:
+
+```html
+<link
+  href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;500;600;700&display=swap"
+  rel="stylesheet"
+/>
+```
 
 ## Where to begin?
 

--- a/i18n/English.json
+++ b/i18n/English.json
@@ -2,7 +2,7 @@
     "filters": {
         "dateFormat": "DD/MM/YYYY",
         "close": "Close",
-        "clear": "Clear",
+        "clear": "Clear All",
         "apply": "Apply",
         "period": {
             "after": "After",

--- a/i18n/English.json
+++ b/i18n/English.json
@@ -43,8 +43,8 @@
             "collapse": "Collapse"
         },
         "sorting": {
-            "increase": "Sort from A - Z",
-            "decrease": "Sort from Z - A"
+            "ascending": "Sort Ascending",
+            "descending": "Sort Descending"
         },
         "selectRow": "Select this row.",
         "selectAll": "Select all rows"

--- a/i18n/French.json
+++ b/i18n/French.json
@@ -43,8 +43,8 @@
             "collapse": "Crash"
         },
         "sorting": {
-            "increase": "Trier de A à Z",
-            "decrease": "Trier de Z à A"
+            "ascending": "Sort Ascending",
+            "descending": "Sort Descending"
         },
         "selectRow": "Sélectionner la ligne",
         "selectAll": "Sélectionner toutes les lignes"

--- a/i18n/Spanish.json
+++ b/i18n/Spanish.json
@@ -43,8 +43,8 @@
             "collapse": "Colapsar"
         },
         "sorting": {
-            "increase": "Ordenar A-Z",
-            "decrease": "Ordenar Z-A"
+            "ascending": "Sort Ascending",
+            "descending": "Sort Descending"
         },
         "selectRow": "Select this row.",
         "selectAll": "Select all rows"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "elm-test": "^0.19.1-revision7",
     "i18n-json-to-elm": "^1.2.3",
     "node-elm-compiler": "^5.0.6",
-    "paack-ui-assets": "^0.1.1",
+    "paack-ui-assets": "^0.1.2",
     "parcel-bundler": "^1.12.5",
     "parcel-plugin-asset-copier": "^1.1.0"
   },

--- a/showcase/public/index.html
+++ b/showcase/public/index.html
@@ -45,7 +45,7 @@
 
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
 

--- a/showcase/src/Layouts/Stories.elm
+++ b/showcase/src/Layouts/Stories.elm
@@ -95,7 +95,7 @@ selectedView renderConfig model =
                 , Element.column
                     [ Element.spacing 8 ]
                     [ "Year: "
-                        ++ book.year
+                        ++ String.fromInt book.year
                         |> Text.body1
                         |> Text.renderElement renderConfig
                     , "ISBN: "

--- a/showcase/src/Tables/Book.elm
+++ b/showcase/src/Tables/Book.elm
@@ -21,7 +21,7 @@ import UI.Utils.TypeNumbers as T
 type alias Book =
     { author : String
     , title : String
-    , year : String
+    , year : Int
     , acquired : Time.Posix
     , read : Time.Posix
     , isbn : String
@@ -39,13 +39,13 @@ filters =
             (\item selected ->
                 case selected of
                     0 ->
-                        String.startsWith "201" item.year
+                        String.startsWith "201" <| String.fromInt item.year
 
                     1 ->
-                        String.startsWith "20" item.year
+                        String.startsWith "20" <| String.fromInt item.year
 
                     2 ->
-                        String.startsWith "19" item.year
+                        String.startsWith "19" <| String.fromInt item.year
 
                     _ ->
                         False
@@ -59,72 +59,72 @@ sorters =
     Stateful.sortersEmpty
         |> Stateful.sortBy .title
         |> Stateful.sortBy .author
-        |> Stateful.sortBy .year
-        |> Stateful.sortBy (.acquired >> posixToMillis >> String.fromInt)
-        |> Stateful.sortBy (.read >> posixToMillis >> String.fromInt)
+        |> Stateful.sortByInt .year
+        |> Stateful.sortByInt (.acquired >> posixToMillis)
+        |> Stateful.sortByInt (.read >> posixToMillis)
 
 
 books : List Book
 books =
     [ { author = "Dan Brown"
       , title = "Angels & Demons"
-      , year = "2000"
+      , year = 2000
       , acquired = millisToPosix 1118405730000
       , read = millisToPosix 1118405730000
       , isbn = "9780671027360"
       }
     , { author = "Dan Brown"
       , title = "The Da Vinci Code"
-      , year = "2003"
+      , year = 2003
       , acquired = millisToPosix 1183983330000
       , read = millisToPosix 1183983330000
       , isbn = "9780385504201"
       }
     , { author = "Dan Brown"
       , title = "The Lost Symbol"
-      , year = "2009"
+      , year = 2009
       , acquired = millisToPosix 1540210530000
       , read = millisToPosix 1540210530000
       , isbn = "9780385504225"
       }
     , { author = "Dan Brown"
       , title = "Inferno"
-      , year = "2013"
+      , year = 2013
       , acquired = millisToPosix 1538655330000
       , read = millisToPosix 1538655330000
       , isbn = "9789955133971"
       }
     , { author = "Dan Brown"
       , title = "Origin"
-      , year = "2017"
+      , year = 2017
       , acquired = millisToPosix 1486037730000
       , read = millisToPosix 1486037730000
       , isbn = "9788804681960"
       }
     , { author = "Suzanne Collins"
       , title = "The Hunger Games"
-      , year = "2008"
+      , year = 2008
       , acquired = millisToPosix 1230120930000
       , read = millisToPosix 1230120930000
       , isbn = "9780545229937"
       }
     , { author = "Agatha Christie"
       , title = "Murder on the Orient Express"
-      , year = "1933"
+      , year = 1933
       , acquired = millisToPosix 969711330000
       , read = millisToPosix 969711330000
       , isbn = "9780062693662"
       }
     , { author = "Clive Staples Lewis"
       , title = "The Chronicles of Narnia: The Lion, the Witch and The Wardrobe"
-      , year = "1950"
+      , year = 1950
       , acquired = millisToPosix 968701330000
       , read = millisToPosix 969210230000
       , isbn = "9780064404990"
       }
     , { author = "John Ronald Reuel Tolkien"
       , title = "Lord of The Rings, Part 3, The Return of the King"
-      , year = "1955"
+      , year = 1955
       , acquired = millisToPosix 964701330000
       , read = millisToPosix 965210230000
       , isbn = "9780618002245"
@@ -160,7 +160,7 @@ toTableRow =
             rowEmpty
                 |> rowCellText (Text.body2 title)
                 |> rowCellText (Text.body2 author)
-                |> rowCellText (Text.caption year)
+                |> rowCellText (Text.caption <| String.fromInt year)
                 |> rowCellText (Text.caption <| DateInput.toDD_MM_YYYY "/" <| DateInput.fromPosix Time.utc acquired)
                 |> rowCellText (Text.caption <| DateInput.toDD_MM_YYYY "/" <| DateInput.fromPosix Time.utc read)
     }
@@ -194,4 +194,4 @@ toTableDetails { author, acquired, read } =
 
 toTableCover : Book -> Stateful.Cover
 toTableCover { title, year } =
-    { title = title, caption = Just year }
+    { title = title, caption = Just <| String.fromInt year }

--- a/src/UI/I18n/English.elm
+++ b/src/UI/I18n/English.elm
@@ -80,8 +80,8 @@ tablesDetails =
 
 tablesSorting : TablesSorting
 tablesSorting =
-    { increase = "Sort from A - Z"
-    , decrease = "Sort from Z - A"
+    { ascending = "Sort Ascending"
+    , descending = "Sort Descending"
     }
 
 

--- a/src/UI/I18n/English.elm
+++ b/src/UI/I18n/English.elm
@@ -29,7 +29,7 @@ filters : Filters
 filters =
     { dateFormat = "DD/MM/YYYY"
     , close = "Close"
-    , clear = "Clear"
+    , clear = "Clear All"
     , apply = "Apply"
     , period = filtersPeriod
     , range = filtersRange

--- a/src/UI/I18n/French.elm
+++ b/src/UI/I18n/French.elm
@@ -80,8 +80,8 @@ tablesDetails =
 
 tablesSorting : TablesSorting
 tablesSorting =
-    { increase = "Trier de A à Z"
-    , decrease = "Trier de Z à A"
+    { ascending = "Sort Ascending"
+    , descending = "Sort Descending"
     }
 
 

--- a/src/UI/I18n/Spanish.elm
+++ b/src/UI/I18n/Spanish.elm
@@ -80,8 +80,8 @@ tablesDetails =
 
 tablesSorting : TablesSorting
 tablesSorting =
-    { increase = "Ordenar A-Z"
-    , decrease = "Ordenar Z-A"
+    { ascending = "Sort Ascending"
+    , descending = "Sort Descending"
     }
 
 

--- a/src/UI/I18n/Types.elm
+++ b/src/UI/I18n/Types.elm
@@ -67,8 +67,8 @@ type alias TablesDetails =
 
 
 type alias TablesSorting =
-    { increase : String
-    , decrease : String
+    { ascending : String
+    , descending : String
     }
 
 

--- a/src/UI/Internal/Filter/Model.elm
+++ b/src/UI/Internal/Filter/Model.elm
@@ -1,0 +1,635 @@
+module UI.Internal.Filter.Model exposing (..)
+
+import Array exposing (Array)
+import Time exposing (Posix)
+import UI.Internal.Basics exposing (flip, maybeNotThen)
+import UI.Internal.DateInput as DateInput exposing (DateInput(..), PeriodComparison(..), PeriodDate, RangeDate)
+
+
+
+-- Constant
+
+
+dateSeparator : String
+dateSeparator =
+    "/"
+
+
+
+-- Main Type
+
+
+type Filter msg item
+    = SingleTextFilter (SingleTextFilterConfig msg item)
+    | MultiTextFilter (MultiTextFilterConfig msg item)
+    | SingleDateFilter (SingleDateFilterConfig msg item)
+    | RangeDateFilter (RangeDateFilterConfig msg item)
+    | PeriodDateFilter (PeriodDateFilterConfig msg item)
+    | SelectFilter (List String) (SelectFilterConfig msg item)
+
+
+type alias Editable value =
+    { current : Maybe value
+    , applied : Maybe value
+    }
+
+
+type alias FilterConfig msg value item =
+    { editable : Editable value
+    , strategy : Strategy msg value item
+    }
+
+
+type Strategy msg value item
+    = Local (item -> value -> Bool)
+    | Remote (RemoteMessages msg value)
+
+
+type alias RemoteMessages msg value =
+    { applyMsg : value -> msg, clearMsg : msg }
+
+
+configSetEditable : FilterConfig msg value item -> Editable value -> FilterConfig msg value item
+configSetEditable config newEditable =
+    { config | editable = newEditable }
+
+
+
+-- Editable
+
+
+editableEmpty : Editable something
+editableEmpty =
+    { current = Nothing, applied = Nothing }
+
+
+editableWithDefault : data -> Editable data -> data
+editableWithDefault default { current, applied } =
+    current
+        |> maybeNotThen applied
+        |> Maybe.withDefault default
+
+
+editableApply : Editable data -> Editable data
+editableApply { current } =
+    { current = Nothing, applied = current }
+
+
+editableSetCurrent : value -> Editable value -> Editable value
+editableSetCurrent new old =
+    { old | current = Just new }
+
+
+editableMapCurrent : (Maybe value -> value) -> Editable value -> Editable value
+editableMapCurrent applier old =
+    { old | current = Just <| applier <| maybeNotThen old.applied <| old.current }
+
+
+
+-- Strategy
+
+
+strategyLocal : (item -> value -> Bool) -> Strategy msg value item
+strategyLocal isKept =
+    Local isKept
+
+
+strategyRemote : RemoteMessages msg value -> Strategy msg value item
+strategyRemote messages =
+    Remote messages
+
+
+
+-- Get Filters
+
+
+isEdited : Filter msg item -> Bool
+isEdited filter =
+    case filter of
+        SingleTextFilter { editable } ->
+            editable.current /= Nothing
+
+        MultiTextFilter { editable } ->
+            editable.current /= Nothing
+
+        SingleDateFilter { editable } ->
+            editable.current /= Nothing
+
+        RangeDateFilter { editable } ->
+            editable.current /= Nothing
+
+        PeriodDateFilter { editable } ->
+            editable.current /= Nothing
+
+        SelectFilter _ { editable } ->
+            editable.current /= Nothing
+
+
+isApplied : Filter msg item -> Bool
+isApplied filter =
+    case filter of
+        SingleTextFilter { editable } ->
+            editable.applied /= Nothing
+
+        MultiTextFilter { editable } ->
+            editable.applied /= Nothing
+
+        SingleDateFilter { editable } ->
+            editable.applied /= Nothing
+
+        RangeDateFilter { editable } ->
+            editable.applied /= Nothing
+
+        PeriodDateFilter { editable } ->
+            editable.applied /= Nothing
+
+        SelectFilter _ { editable } ->
+            editable.applied /= Nothing
+
+
+localAppliedMap : FilterConfig msg value item -> Maybe (item -> Bool)
+localAppliedMap { editable, strategy } =
+    case strategy of
+        Local applier ->
+            Maybe.map (flip applier) editable.applied
+
+        Remote _ ->
+            Nothing
+
+
+filterGet : Filter msg item -> Maybe (item -> Bool)
+filterGet filter =
+    case filter of
+        SingleTextFilter config ->
+            localAppliedMap config
+
+        MultiTextFilter config ->
+            localAppliedMap config
+
+        SingleDateFilter config ->
+            localAppliedMap config
+
+        RangeDateFilter config ->
+            localAppliedMap config
+
+        PeriodDateFilter config ->
+            localAppliedMap config
+
+        SelectFilter _ config ->
+            localAppliedMap config
+
+
+
+-- SingleText
+
+
+type alias SingleTextFilterConfig msg item =
+    FilterConfig msg String item
+
+
+singleTextLocal :
+    Maybe String
+    -> (item -> String)
+    -> Filter msg item
+singleTextLocal initValue getStr =
+    let
+        applier item current =
+            getStr item
+                |> String.toLower
+                |> String.contains (String.toLower current)
+    in
+    SingleTextFilter
+        { editable = { applied = initValue, current = Nothing }
+        , strategy = strategyLocal applier
+        }
+
+
+singleTextRemote :
+    Maybe String
+    -> (Maybe String -> msg)
+    -> Filter msg item
+singleTextRemote initValue applyMsg =
+    SingleTextFilter
+        { editable = { applied = initValue, current = Nothing }
+        , strategy =
+            strategyRemote
+                { applyMsg = Just >> applyMsg
+                , clearMsg = applyMsg Nothing
+                }
+        }
+
+
+singleTextEdit : String -> Filter msg item -> Filter msg item
+singleTextEdit value filter =
+    case filter of
+        SingleTextFilter config ->
+            config.editable
+                |> editableSetCurrent value
+                |> configSetEditable config
+                |> SingleTextFilter
+
+        _ ->
+            filter
+
+
+
+-- MultiText
+
+
+type alias MultiTextFilterConfig msg item =
+    FilterConfig msg (Array String) item
+
+
+multiTextLocal :
+    List String
+    -> (item -> String)
+    -> Filter msg item
+multiTextLocal initValue getStr =
+    let
+        applier item current =
+            getStr item
+                |> String.toLower
+                |> String.contains (String.toLower current)
+
+        strategy item valueArray =
+            valueArray
+                |> Array.toList
+                |> List.any (applier item)
+    in
+    MultiTextFilter
+        { editable = { applied = listToMaybeArray initValue, current = Nothing }
+        , strategy = strategyLocal strategy
+        }
+
+
+multiTextRemote :
+    List String
+    -> (List String -> msg)
+    -> Filter msg item
+multiTextRemote initValue applyMsg =
+    MultiTextFilter
+        { editable = { applied = listToMaybeArray initValue, current = Nothing }
+        , strategy =
+            strategyRemote
+                { applyMsg = Array.toList >> applyMsg
+                , clearMsg = applyMsg []
+                }
+        }
+
+
+multiTextEdit : Int -> String -> Filter msg item -> Filter msg item
+multiTextEdit field value filter =
+    case filter of
+        MultiTextFilter config ->
+            config.editable
+                |> editableWithDefault Array.empty
+                |> flexibleArray field value
+                |> flip editableSetCurrent config.editable
+                |> configSetEditable config
+                |> MultiTextFilter
+
+        _ ->
+            filter
+
+
+listToMaybeArray : List a -> Maybe (Array a)
+listToMaybeArray list =
+    if list == [] then
+        Nothing
+
+    else
+        Just <| Array.fromList list
+
+
+flexibleArray : Int -> String -> Array String -> Array String
+flexibleArray index newValue array =
+    if Array.length array == index then
+        if String.isEmpty newValue then
+            array
+
+        else
+            Array.push newValue array
+
+    else
+        array
+            |> Array.set index newValue
+            |> Array.filter (not << String.isEmpty)
+
+
+
+-- SingleDate
+
+
+type alias SingleDateFilterConfig msg item =
+    FilterConfig msg DateInput item
+
+
+singleDateLocal :
+    Time.Zone
+    -> Maybe Posix
+    -> (item -> Posix)
+    -> Filter msg item
+singleDateLocal timeZone initValue getPosix =
+    let
+        compare posix current =
+            DateInput.isPosixEqual current timeZone posix
+
+        applier item current =
+            compare (getPosix item) current
+    in
+    SingleDateFilter
+        { editable = { applied = Maybe.map (DateInput.fromPosix timeZone) initValue, current = Nothing }
+        , strategy = strategyLocal applier
+        }
+
+
+singleDateRemote :
+    Time.Zone
+    -> Maybe Posix
+    -> (Maybe DateInput -> msg)
+    -> Filter msg item
+singleDateRemote timeZone initValue applyMsg =
+    SingleDateFilter
+        { editable = { applied = Maybe.map (DateInput.fromPosix timeZone) initValue, current = Nothing }
+        , strategy =
+            strategyRemote
+                { applyMsg = Just >> applyMsg
+                , clearMsg = applyMsg Nothing
+                }
+        }
+
+
+singleDateEdit : String -> Filter msg item -> Filter msg item
+singleDateEdit value filter =
+    case filter of
+        SingleDateFilter config ->
+            config.editable
+                |> editableSetCurrent (DateInput.parseDD_MM_YYYY dateSeparator value)
+                |> configSetEditable config
+                |> SingleDateFilter
+
+        _ ->
+            filter
+
+
+
+-- RangeDate
+
+
+type alias RangeDateFilterConfig msg item =
+    FilterConfig msg RangeDate item
+
+
+rangeDateLocal :
+    Time.Zone
+    -> Maybe Posix
+    -> Maybe Posix
+    -> (item -> Posix)
+    -> Filter msg item
+rangeDateLocal timeZone fromInit toInit getPosix =
+    let
+        compare posix { from, to } =
+            DateInput.isPosixBetween timeZone posix from to
+
+        applier item current =
+            compare (getPosix item) current
+    in
+    RangeDateFilter
+        { editable = { applied = rangeDateInit timeZone fromInit toInit, current = Nothing }
+        , strategy = strategyLocal applier
+        }
+
+
+rangeDateRemote :
+    Time.Zone
+    -> Maybe Posix
+    -> Maybe Posix
+    -> (Maybe RangeDate -> msg)
+    -> Filter msg item
+rangeDateRemote timeZone fromInit toInit applyMsg =
+    RangeDateFilter
+        { editable = { applied = rangeDateInit timeZone fromInit toInit, current = Nothing }
+        , strategy =
+            strategyRemote
+                { applyMsg = Just >> applyMsg
+                , clearMsg = applyMsg Nothing
+                }
+        }
+
+
+rangeDateInit : Time.Zone -> Maybe Posix -> Maybe Posix -> Maybe RangeDate
+rangeDateInit timeZone fromInit toInit =
+    case ( fromInit, toInit ) of
+        ( Just fromPosix, Just toPosix ) ->
+            Just { from = DateInput.fromPosix timeZone fromPosix, to = DateInput.fromPosix timeZone toPosix }
+
+        ( Just fromPosix, Nothing ) ->
+            Just { from = DateInput.fromPosix timeZone fromPosix, to = DateInvalid "" }
+
+        ( Nothing, Just toPosix ) ->
+            Just { from = DateInvalid "", to = DateInput.fromPosix timeZone toPosix }
+
+        ( Nothing, Nothing ) ->
+            Nothing
+
+
+rangeDateFromEdit : String -> Filter msg item -> Filter msg item
+rangeDateFromEdit value filter =
+    case filter of
+        RangeDateFilter config ->
+            config.editable
+                |> editableMapCurrent
+                    (\maybeCurrent ->
+                        { from = DateInput.parseDD_MM_YYYY dateSeparator value
+                        , to =
+                            maybeCurrent
+                                |> Maybe.map .to
+                                |> Maybe.withDefault (DateInvalid "")
+                        }
+                    )
+                |> configSetEditable config
+                |> RangeDateFilter
+
+        _ ->
+            filter
+
+
+rangeDateToEdit : String -> Filter msg item -> Filter msg item
+rangeDateToEdit value filter =
+    case filter of
+        RangeDateFilter config ->
+            config.editable
+                |> editableMapCurrent
+                    (\maybeCurrent ->
+                        { from =
+                            maybeCurrent
+                                |> Maybe.map .from
+                                |> Maybe.withDefault (DateInvalid "")
+                        , to = DateInput.parseDD_MM_YYYY dateSeparator value
+                        }
+                    )
+                |> configSetEditable config
+                |> RangeDateFilter
+
+        _ ->
+            filter
+
+
+
+-- PeriodDate
+
+
+type alias PeriodDateFilterConfig msg item =
+    FilterConfig msg PeriodDate item
+
+
+periodDateInit : Time.Zone -> Maybe Posix -> Maybe PeriodComparison -> Maybe PeriodDate
+periodDateInit timeZone posixInit periodInit =
+    case ( posixInit, periodInit ) of
+        ( Just posix, Just period ) ->
+            Just { date = DateInput.fromPosix timeZone posix, comparison = period }
+
+        ( Just posix, Nothing ) ->
+            Just { date = DateInput.fromPosix timeZone posix, comparison = On }
+
+        ( Nothing, Just period ) ->
+            Just { date = DateInvalid "", comparison = period }
+
+        ( Nothing, Nothing ) ->
+            Nothing
+
+
+periodDateLocal :
+    Time.Zone
+    -> Maybe Posix
+    -> Maybe PeriodComparison
+    -> (item -> Posix)
+    -> Filter msg item
+periodDateLocal timeZone posixInit periodInit getPosix =
+    let
+        compare posix { date, comparison } =
+            case comparison of
+                On ->
+                    DateInput.isPosixEqual date timeZone posix
+
+                Before ->
+                    DateInput.isPosixBefore date timeZone posix
+
+                After ->
+                    DateInput.isPosixAfter date timeZone posix
+
+        applier item current =
+            compare (getPosix item) current
+    in
+    PeriodDateFilter
+        { editable = { applied = periodDateInit timeZone posixInit periodInit, current = Nothing }
+        , strategy = strategyLocal applier
+        }
+
+
+periodDateRemote :
+    Time.Zone
+    -> Maybe Posix
+    -> Maybe PeriodComparison
+    -> (Maybe PeriodDate -> msg)
+    -> Filter msg item
+periodDateRemote timeZone posixInit periodInit applyMsg =
+    PeriodDateFilter
+        { editable = { applied = periodDateInit timeZone posixInit periodInit, current = Nothing }
+        , strategy =
+            strategyRemote
+                { applyMsg = Just >> applyMsg
+                , clearMsg = applyMsg Nothing
+                }
+        }
+
+
+periodDateEdit : String -> Filter msg item -> Filter msg item
+periodDateEdit value filter =
+    case filter of
+        PeriodDateFilter config ->
+            config.editable
+                |> editableMapCurrent
+                    (\maybeCurrent ->
+                        { date = DateInput.parseDD_MM_YYYY dateSeparator value
+                        , comparison =
+                            maybeCurrent
+                                |> Maybe.map .comparison
+                                |> Maybe.withDefault On
+                        }
+                    )
+                |> configSetEditable config
+                |> PeriodDateFilter
+
+        _ ->
+            filter
+
+
+periodDateComparisonEdit : PeriodComparison -> Filter msg item -> Filter msg item
+periodDateComparisonEdit value filter =
+    case filter of
+        PeriodDateFilter config ->
+            config.editable
+                |> editableMapCurrent
+                    (\maybeCurrent ->
+                        { date =
+                            maybeCurrent
+                                |> Maybe.map .date
+                                |> Maybe.withDefault (DateInvalid "")
+                        , comparison = value
+                        }
+                    )
+                |> configSetEditable config
+                |> PeriodDateFilter
+
+        _ ->
+            filter
+
+
+
+-- SelectFilter
+
+
+type alias SelectFilterConfig msg item =
+    FilterConfig msg Int item
+
+
+selectLocal :
+    List String
+    -> Maybe Int
+    -> (item -> Int -> Bool)
+    -> Filter msg item
+selectLocal list initValue filter =
+    SelectFilter list
+        { editable = { applied = initValue, current = Nothing }
+        , strategy = strategyLocal filter
+        }
+
+
+selectRemote :
+    List String
+    -> Maybe Int
+    -> (Maybe Int -> msg)
+    -> Filter msg item
+selectRemote list initValue applyMsg =
+    SelectFilter list
+        { editable = { applied = initValue, current = Nothing }
+        , strategy =
+            strategyRemote
+                { applyMsg = Just >> applyMsg
+                , clearMsg = applyMsg Nothing
+                }
+        }
+
+
+selectEdit : Int -> Filter msg item -> Filter msg item
+selectEdit value filter =
+    case filter of
+        SelectFilter list config ->
+            config.editable
+                |> editableSetCurrent value
+                |> configSetEditable config
+                |> SelectFilter list
+
+        _ ->
+            filter

--- a/src/UI/Internal/Filter/Model.elm
+++ b/src/UI/Internal/Filter/Model.elm
@@ -147,6 +147,28 @@ isApplied filter =
             editable.applied /= Nothing
 
 
+appliedLength : Filter msg item -> Maybe Int
+appliedLength filter =
+    case filter of
+        SingleTextFilter { editable } ->
+            Maybe.map (always 1) editable.applied
+
+        MultiTextFilter { editable } ->
+            Maybe.map Array.length editable.applied
+
+        SingleDateFilter { editable } ->
+            Maybe.map (always 1) editable.applied
+
+        RangeDateFilter { editable } ->
+            Maybe.map (always 1) editable.applied
+
+        PeriodDateFilter { editable } ->
+            Maybe.map (always 1) editable.applied
+
+        SelectFilter _ { editable } ->
+            Maybe.map (always 1) editable.applied
+
+
 localAppliedMap : FilterConfig msg value item -> Maybe (item -> Bool)
 localAppliedMap { editable, strategy } =
     case strategy of

--- a/src/UI/Internal/Filter/Sorter.elm
+++ b/src/UI/Internal/Filter/Sorter.elm
@@ -1,4 +1,4 @@
-module UI.Internal.Filter.Sorter exposing (..)
+module UI.Internal.Filter.Sorter exposing (Sorter(..), SortingDirection(..), preview, sort)
 
 
 type Sorter item
@@ -31,3 +31,22 @@ sort sorter list =
 
         IntegerSortable retrieve ->
             List.sortBy retrieve list
+
+
+preview : Sorter item -> Maybe ( String, String )
+preview sorter =
+    case sorter of
+        AlphabeticalSortable _ ->
+            Just ( "A", "Z" )
+
+        CharSortable _ ->
+            Just ( "A", "Z" )
+
+        CustomSortable _ ->
+            Nothing
+
+        FloatSortable _ ->
+            Just ( "0", "9" )
+
+        IntegerSortable _ ->
+            Just ( "0", "9" )

--- a/src/UI/Internal/Filter/Sorter.elm
+++ b/src/UI/Internal/Filter/Sorter.elm
@@ -3,6 +3,10 @@ module UI.Internal.Filter.Sorter exposing (..)
 
 type Sorter item
     = AlphabeticalSortable (item -> String)
+    | CharSortable (item -> Char)
+    | CustomSortable (List item -> List item)
+    | FloatSortable (item -> Float)
+    | IntegerSortable (item -> Int)
 
 
 type SortingDirection
@@ -10,93 +14,20 @@ type SortingDirection
     | SortDescending
 
 
-type alias AlphanumericSortConfig item =
-    { retrieve : item -> String
-    , smallerFirst : Bool
-    , emptyOnTail : Bool
-    , numbersFirst : Bool
-    }
-
-
-alphanumericSort : AlphanumericSortConfig item -> List item -> List item
-alphanumericSort { retrieve, smallerFirst, emptyOnTail, numbersFirst } list =
-    let
-        nonEmptySort nonEmptyList =
-            if smallerFirst then
-                List.sortWith
-                    (\a b -> compareSmallerFirst (retrieve a) (retrieve b))
-                    nonEmptyList
-
-            else
-                List.sortBy retrieve nonEmptyList
-
-        alphanumericMerge ( numbers, alphanums, empties ) =
-            let
-                sortedNumbers =
-                    numbers
-                        |> List.sortBy Tuple.first
-                        |> List.map Tuple.second
-
-                sortedAlphanums =
-                    nonEmptySort alphanums
-            in
-            if emptyOnTail then
-                sortedNumbers ++ sortedAlphanums ++ empties
-
-            else
-                empties ++ sortedNumbers ++ sortedAlphanums
-    in
-    if numbersFirst then
-        List.foldr
-            (alphanumericPartition retrieve)
-            ( [], [], [] )
-            list
-            |> alphanumericMerge
-
-    else if emptyOnTail then
-        List.partition (retrieve >> String.isEmpty)
-            list
-            |> Tuple.mapSecond nonEmptySort
-            |> (\( a, b ) -> b ++ a)
-
-    else
-        nonEmptySort list
-
-
-compareSmallerFirst : String -> String -> Order
-compareSmallerFirst a b =
-    case compare (String.length a) (String.length b) of
-        EQ ->
-            compare a b
-
-        another ->
-            another
-
-
-alphanumericPartition :
-    (item -> String)
-    -> item
-    -> ( List ( Float, item ), List item, List item )
-    -> ( List ( Float, item ), List item, List item )
-alphanumericPartition retrieve elem ( numbers, alphanums, empties ) =
-    let
-        string =
-            retrieve elem
-    in
-    if String.isEmpty string then
-        ( numbers, alphanums, elem :: empties )
-
-    else
-        case String.toFloat string of
-            Just float ->
-                ( ( float, elem ) :: numbers, alphanums, empties )
-
-            Nothing ->
-                ( numbers, elem :: alphanums, empties )
-
-
 sort : Sorter item -> List item -> List item
 sort sorter list =
     case sorter of
         AlphabeticalSortable retrieve ->
+            List.sortBy retrieve list
+
+        CharSortable retrieve ->
+            List.sortBy retrieve list
+
+        CustomSortable applier ->
+            applier list
+
+        FloatSortable retrieve ->
+            List.sortBy retrieve list
+
+        IntegerSortable retrieve ->
             List.sortBy retrieve list

--- a/src/UI/Internal/Filter/Sorter.elm
+++ b/src/UI/Internal/Filter/Sorter.elm
@@ -1,0 +1,72 @@
+module UI.Internal.Filter.Sorter exposing (..)
+
+
+type Sorter item
+    = AlphanumericSortable (AlphanumericSortConfig item)
+    | IntegerSortable (item -> Int)
+    | FloatingSortable (item -> Float)
+    | CharSortable (item -> Float)
+    | CustomSortable (item -> item -> Order)
+
+
+type SortingDirection
+    = SortIncreasing
+    | SortDecreasing
+
+
+type alias AlphanumericSortConfig item =
+    { retrieve : item -> String
+    , smallerFirst : Bool
+    , emptyOnTail : Bool
+    }
+
+
+alphanumericSort : AlphanumericSortConfig item -> List item -> List item
+alphanumericSort { retrieve, smallerFirst, emptyOnTail } list =
+    let
+        nonEmptySort nonEmptyList =
+            if smallerFirst then
+                List.sortWith
+                    (\a b -> compareSmallerFirst (retrieve a) (retrieve b))
+                    nonEmptyList
+
+            else
+                List.sortBy retrieve nonEmptyList
+    in
+    if emptyOnTail then
+        List.partition (retrieve >> String.isEmpty)
+            list
+            |> Tuple.mapSecond nonEmptySort
+            |> (\( a, b ) -> b ++ a)
+
+    else
+        nonEmptySort list
+
+
+compareSmallerFirst : String -> String -> Order
+compareSmallerFirst a b =
+    case compare (String.length a) (String.length b) of
+        EQ ->
+            compare a b
+
+        another ->
+            another
+
+
+sort : Sorter item -> List item -> List item
+sort sorter list =
+    case sorter of
+        AlphanumericSortable config ->
+            alphanumericSort config list
+
+        IntegerSortable retrieve ->
+            List.sortBy retrieve list
+
+        FloatingSortable retrieve ->
+            List.sortBy retrieve list
+
+        CharSortable retrieve ->
+            List.sortBy retrieve list
+
+        CustomSortable fn ->
+            List.sortWith fn list

--- a/src/UI/Internal/Filter/Sorter.elm
+++ b/src/UI/Internal/Filter/Sorter.elm
@@ -3,11 +3,6 @@ module UI.Internal.Filter.Sorter exposing (..)
 
 type Sorter item
     = AlphabeticalSortable (item -> String)
-    | AlphanumericSortable (AlphanumericSortConfig item)
-    | CharSortable (item -> Char)
-    | CustomSortable (item -> item -> Order)
-    | FloatingSortable (item -> Float)
-    | IntegerSortable (item -> Int)
 
 
 type SortingDirection
@@ -104,19 +99,4 @@ sort : Sorter item -> List item -> List item
 sort sorter list =
     case sorter of
         AlphabeticalSortable retrieve ->
-            List.sortBy retrieve list
-
-        AlphanumericSortable config ->
-            alphanumericSort config list
-
-        CharSortable retrieve ->
-            List.sortBy retrieve list
-
-        CustomSortable fn ->
-            List.sortWith fn list
-
-        FloatingSortable retrieve ->
-            List.sortBy retrieve list
-
-        IntegerSortable retrieve ->
             List.sortBy retrieve list

--- a/src/UI/Internal/Filter/Sorter.elm
+++ b/src/UI/Internal/Filter/Sorter.elm
@@ -4,7 +4,7 @@ module UI.Internal.Filter.Sorter exposing (..)
 type Sorter item
     = AlphabeticalSortable (item -> String)
     | AlphanumericSortable (AlphanumericSortConfig item)
-    | CharSortable (item -> Float)
+    | CharSortable (item -> Char)
     | CustomSortable (item -> item -> Order)
     | FloatingSortable (item -> Float)
     | IntegerSortable (item -> Int)

--- a/src/UI/Internal/Filter/Sorter.elm
+++ b/src/UI/Internal/Filter/Sorter.elm
@@ -6,8 +6,8 @@ type Sorter item
 
 
 type SortingDirection
-    = SortIncreasing
-    | SortDecreasing
+    = SortAscending
+    | SortDescending
 
 
 type alias AlphanumericSortConfig item =

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -273,8 +273,10 @@ bodyToElement renderConfig (Body { label, closeMsg } common { sorting, rows, but
                 { offset = ( 0, 6 )
                 , size = 0
                 , blur = 20
-                , color = Element.rgba 0 0 0 0.5
+                , color = Element.rgba 0 0 0 0.09
                 }
+            , Border.width 1
+            , Border.color Colors.gray300
             , roundedBorders
             , width
             ]
@@ -291,9 +293,7 @@ bodyToElement renderConfig (Body { label, closeMsg } common { sorting, rows, but
             , bodyButtons renderConfig common.size buttons
             ]
     in
-    Element.column attrs
-        bodyRows
-        |> Element.clickElsewhereToLeave closeMsg []
+    Element.customOverlay closeMsg [] <| Element.column attrs bodyRows
 
 
 bodyHeader : RenderConfig -> FilterSize -> msg -> String -> Element msg
@@ -303,7 +303,7 @@ bodyHeader renderConfig size closeMsg label =
             headerProportions size
 
         paddingWithBorders =
-            { left = padding.left + 2
+            { left = padding.left + 1
             , top = padding.top + 1
             , bottom = padding.bottom + 1
             , right = padding.right
@@ -393,25 +393,13 @@ sortAs renderConfig direction { fontSize, iconSize } sortingData label msg =
         labelParagraph =
             case ( sortingData.preview, direction ) of
                 ( Just { smaller, larger }, SortAscending ) ->
-                    [ Element.text label
-                    , Element.text " ("
-                    , Element.text smaller
-                    , Element.text " - "
-                    , Element.text larger
-                    , Element.text ")"
-                    ]
+                    [ label, " (", smaller, " - ", larger, ")" ]
 
                 ( Just { smaller, larger }, SortDescending ) ->
-                    [ Element.text label
-                    , Element.text " ("
-                    , Element.text larger
-                    , Element.text " - "
-                    , Element.text smaller
-                    , Element.text ")"
-                    ]
+                    [ label, " (", larger, " - ", smaller, ")" ]
 
                 _ ->
-                    [ Element.text label ]
+                    [ label ]
     in
     Element.row
         [ Element.width fill
@@ -432,7 +420,9 @@ sortAs renderConfig direction { fontSize, iconSize } sortingData label msg =
             [ Background.color Colors.gray300
             ]
         ]
-        [ Element.paragraph [] labelParagraph
+        [ labelParagraph
+            |> List.map Element.text
+            |> Element.paragraph []
         , sortingIcon renderConfig
             [ Element.alignRight
             ]

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -214,8 +214,7 @@ type Body msg
 
 
 type alias BodySorting msg =
-    { smaller : String
-    , larger : String
+    { preview : Maybe { smaller : String, larger : String }
     , ascendingSortMsg : msg
     , descendingSortMsg : msg
     , clearSortMsg : msg
@@ -390,6 +389,29 @@ sortAs renderConfig direction { fontSize, iconSize } sortingData label msg =
 
             else
                 ( Colors.mainBackground, msg )
+
+        labelParagraph =
+            case ( sortingData.preview, direction ) of
+                ( Just { smaller, larger }, SortAscending ) ->
+                    [ Element.text label
+                    , Element.text " ("
+                    , Element.text smaller
+                    , Element.text " - "
+                    , Element.text larger
+                    , Element.text ")"
+                    ]
+
+                ( Just { smaller, larger }, SortDescending ) ->
+                    [ Element.text label
+                    , Element.text " ("
+                    , Element.text larger
+                    , Element.text " - "
+                    , Element.text smaller
+                    , Element.text ")"
+                    ]
+
+                _ ->
+                    [ Element.text label ]
     in
     Element.row
         [ Element.width fill
@@ -410,14 +432,7 @@ sortAs renderConfig direction { fontSize, iconSize } sortingData label msg =
             [ Background.color Colors.gray300
             ]
         ]
-        [ Element.paragraph []
-            [ Element.text label
-            , Element.text " ("
-            , Element.text sortingData.smaller
-            , Element.text " - "
-            , Element.text sortingData.larger
-            , Element.text ")"
-            ]
+        [ Element.paragraph [] labelParagraph
         , sortingIcon renderConfig
             [ Element.alignRight
             ]

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -1,18 +1,41 @@
-module UI.Internal.Filter.View exposing (..)
+module UI.Internal.Filter.View exposing
+    ( Body
+    , BodySorting
+    , CommonOptions
+    , FilterSize(..)
+    , FilterWidth(..)
+    , Header
+    , body
+    , bodyToElement
+    , bodyWithRows
+    , bodyWithSize
+    , bodyWithSorting
+    , bodyWithWidth
+    , header
+    , headerToElement
+    , headerWithApplied
+    , headerWithSize
+    , headerWithSorting
+    , headerWithWidth
+    , sizeExtraSmall
+    , sizeMedium
+    )
 
-import Element exposing (Element, fill, shrink)
+import Element exposing (Attribute, Element, fill, shrink)
 import Element.Background as Background
 import Element.Border as Border
+import Element.Events as Events
 import Element.Font as Font
-import UI.Button exposing (Button)
+import Html.Attributes as HtmlAttrs
+import UI.Button as Button exposing (Button)
 import UI.Icon as Icon
 import UI.Internal.Colors as Colors
 import UI.Internal.Filter.Sorter exposing (SortingDirection(..))
 import UI.Internal.RenderConfig as RenderConfig
+import UI.Internal.Utils.Element as Element
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Utils.ARIA as ARIA
-import UI.Utils.Element as Element
-import UI.Utils.Focus as Focus
+import UI.Utils.Element as Element exposing (RectangleSides, zeroPadding)
 
 
 type FilterSize
@@ -24,36 +47,31 @@ type FilterWidth
     = WidthFull
 
 
+type alias CommonOptions =
+    { width : FilterWidth
+    , size : FilterSize
+    }
+
+
+sizeExtraSmall : FilterSize
+sizeExtraSmall =
+    ExtraSmall
+
+
+sizeMedium : FilterSize
+sizeMedium =
+    Medium
+
+
+{-| The filter header-state button
+-}
 type Header msg
     = Header
         { label : String, openMsg : msg }
         CommonOptions
         { sorting : Maybe SortingDirection
-        , applied : Maybe { preview : String, discardMsg : msg }
+        , applied : Maybe { preview : String, clearMsg : msg }
         }
-
-
-type Body msg
-    = Body
-        { label : String, closeMsg : msg }
-        CommonOptions
-        { sorting :
-            Maybe
-                { smaller : String
-                , larger : String
-                , ascendingSortMsg : msg
-                , descendingSortMsg : msg
-                }
-        , options : List (Element msg)
-        , buttons : List (Button msg)
-        , closeMsg : msg
-        }
-
-
-type alias CommonOptions =
-    { width : FilterWidth
-    , size : FilterSize
-    }
 
 
 header : String -> msg -> Header msg
@@ -80,16 +98,11 @@ headerWithSorting sorting (Header prop common options) =
 
 
 headerWithApplied :
-    Maybe { preview : String, discardMsg : msg }
+    Maybe { preview : String, clearMsg : msg }
     -> Header msg
     -> Header msg
 headerWithApplied applied (Header prop common options) =
     Header prop common { options | applied = applied }
-
-
-extraSmall : FilterSize
-extraSmall =
-    ExtraSmall
 
 
 headerToElement : RenderConfig -> Header msg -> Element msg
@@ -99,25 +112,10 @@ headerToElement renderConfig (Header { label, openMsg } common { sorting, applie
             RenderConfig.localeTerms renderConfig
 
         { padding, fontSize, iconSize } =
-            if common.size == Medium then
-                { padding = { left = 10, bottom = 7, top = 9, right = 12 }
-                , fontSize = 16
-                , iconSize = 20
-                }
-
-            else
-                { padding = { left = 8, bottom = 7, top = 7, right = 12 }
-                , fontSize = 12
-                , iconSize = 16
-                }
+            headerProportions common.size
 
         attrs =
             ARIA.toElementAttributes ARIA.roleButton
-                ++ Focus.toElementAttributes
-                    { onEnter = openMsg
-                    , tabIndex = 0
-                    , hasFocus = False
-                    }
                 ++ [ Element.width <|
                         if common.width == WidthFull then
                             fill
@@ -128,7 +126,7 @@ headerToElement renderConfig (Header { label, openMsg } common { sorting, applie
                    , Element.spacing 8
                    , Background.color baseColor
                    , Border.width 2
-                   , Border.rounded 6
+                   , roundedBorders
                    , Border.color baseColor
                    , Font.color Colors.navyBlue700
                    , Font.size fontSize
@@ -142,54 +140,18 @@ headerToElement renderConfig (Header { label, openMsg } common { sorting, applie
                         ]
                    , Element.pointer
                    , Element.onIndividualClick openMsg
+                   , Element.onEnterPressed openMsg
+                   , Element.tabIndex 0
                    ]
 
-        body =
-            [ sortingIcon
-            , Element.text label
-            , preview
-            , rightIcon
-            ]
-
         sortingIcon =
-            case sorting of
-                Just SortIncreasing ->
-                    terms.tables.sorting.increase
-                        |> Icon.sortIncreasing
-                        |> Icon.withCustomSize iconSize
-                        |> Icon.renderElement renderConfig
-                        |> Element.el [ Element.width shrink ]
-
-                Just SortDecreasing ->
-                    terms.tables.sorting.decrease
-                        |> Icon.sortDecreasing
-                        |> Icon.withCustomSize iconSize
-                        |> Icon.renderElement renderConfig
-                        |> Element.el [ Element.width shrink ]
-
-                Nothing ->
-                    Element.none
+            headerSortingIcon renderConfig iconSize sorting
 
         { preview, rightIcon, baseColor } =
             case applied of
                 Just appliedData ->
                     { preview = Element.text <| "(" ++ appliedData.preview ++ ")"
-                    , rightIcon =
-                        Icon.close "Discard"
-                            |> Icon.withCustomSize iconSize
-                            |> Icon.renderElement renderConfig
-                            |> Element.el
-                                (ARIA.toElementAttributes ARIA.roleButton
-                                    ++ Focus.toElementAttributes
-                                        { onEnter = appliedData.discardMsg
-                                        , tabIndex = 0
-                                        , hasFocus = False
-                                        }
-                                    ++ [ Element.alignRight
-                                       , Element.pointer
-                                       , Element.onIndividualClick appliedData.discardMsg
-                                       ]
-                                )
+                    , rightIcon = headerClearIcon renderConfig appliedData.clearMsg iconSize
                     , baseColor = Colors.navyBlue200
                     }
 
@@ -203,4 +165,216 @@ headerToElement renderConfig (Header { label, openMsg } common { sorting, applie
                     , baseColor = Colors.gray200
                     }
     in
-    Element.row attrs body
+    Element.row attrs
+        [ sortingIcon
+        , Element.text label
+        , preview
+        , rightIcon
+        ]
+
+
+headerSortingIcon : RenderConfig -> Int -> Maybe SortingDirection -> Element msg
+headerSortingIcon renderConfig iconSize sorting =
+    case sorting of
+        Just SortIncreasing ->
+            RenderConfig.localeTerms renderConfig
+                |> (.tables >> .sorting >> .increase)
+                |> Icon.sortIncreasing
+                |> Icon.withCustomSize iconSize
+                |> Icon.renderElement renderConfig
+                |> Element.el [ Element.width shrink ]
+
+        Just SortDecreasing ->
+            RenderConfig.localeTerms renderConfig
+                |> (.tables >> .sorting >> .decrease)
+                |> Icon.sortDecreasing
+                |> Icon.withCustomSize iconSize
+                |> Icon.renderElement renderConfig
+                |> Element.el [ Element.width shrink ]
+
+        Nothing ->
+            Element.none
+
+
+headerClearIcon : RenderConfig -> msg -> Int -> Element msg
+headerClearIcon renderConfig clearMsg iconSize =
+    Icon.close "Discard"
+        |> Icon.withCustomSize iconSize
+        |> Icon.renderElement renderConfig
+        |> Element.el
+            (ARIA.toElementAttributes ARIA.roleButton
+                ++ [ Element.alignRight
+                   , Element.pointer
+                   , Element.onIndividualClick clearMsg
+                   , Element.onEnterPressed clearMsg
+                   , Element.tabIndex 0
+                   , Border.color (Element.rgba 1 1 1 0)
+                   , Border.width 2
+                   , Element.focused [ Border.color Colors.navyBlue600 ]
+                   ]
+            )
+
+
+headerProportions :
+    FilterSize
+    ->
+        { padding : RectangleSides
+        , fontSize : Int
+        , iconSize : Int
+        }
+headerProportions size =
+    case size of
+        Medium ->
+            { padding = { left = 10, bottom = 7, top = 9, right = 12 }
+            , fontSize = 16
+            , iconSize = 20
+            }
+
+        ExtraSmall ->
+            { padding = { left = 8, bottom = 7, top = 7, right = 12 }
+            , fontSize = 12
+            , iconSize = 16
+            }
+
+
+{-| The filter dialog-state body
+-}
+type Body msg
+    = Body
+        { label : String, closeMsg : msg }
+        CommonOptions
+        { sorting :
+            Maybe (BodySorting msg)
+        , rows : List (Element msg)
+        , buttons : List (Button msg)
+        }
+
+
+type alias BodySorting msg =
+    { smaller : String
+    , larger : String
+    , ascendingSortMsg : msg
+    , descendingSortMsg : msg
+    , clearSortMsg : msg
+    , applied : Maybe SortingDirection
+    }
+
+
+body : String -> msg -> Body msg
+body label closeMsg =
+    Body
+        { label = label, closeMsg = closeMsg }
+        { width = WidthFull, size = Medium }
+        { sorting = Nothing, rows = [], buttons = [] }
+
+
+bodyWithWidth : FilterWidth -> Body msg -> Body msg
+bodyWithWidth width (Body prop common options) =
+    Body prop { common | width = width } options
+
+
+bodyWithSize : FilterSize -> Body msg -> Body msg
+bodyWithSize size (Body prop common options) =
+    Body prop { common | size = size } options
+
+
+bodyWithSorting : BodySorting msg -> Body msg -> Body msg
+bodyWithSorting sorting (Body prop common options) =
+    Body prop common { options | sorting = Just sorting }
+
+
+bodyWithRows : List (Element msg) -> Body msg -> Body msg
+bodyWithRows rows (Body prop common options) =
+    Body prop common { options | rows = rows }
+
+
+bodyToElement : RenderConfig -> Body msg -> Element msg
+bodyToElement renderConfig (Body { label, closeMsg } common { sorting, rows, buttons }) =
+    let
+        attrs =
+            [ Element.zIndex 9
+            , Element.alignTop
+            , Element.tuplesToStyles ( "min-width", "100%" )
+            , Element.tuplesToStyles ( "width", "min-content" )
+            , Colors.mainBackground
+            , Border.shadow
+                { offset = ( 0, 6 )
+                , size = 0
+                , blur = 20
+                , color = Element.rgba 0 0 0 0.5
+                }
+            , roundedBorders
+            ]
+
+        bodyRows =
+            [ bodyHeader renderConfig closeMsg label common.size
+            , bodySorting renderConfig sorting
+            ]
+                ++ rows
+                ++ bodyButtons renderConfig buttons
+    in
+    Element.column attrs
+        bodyRows
+        |> Element.clickElsewhereToLeave closeMsg []
+
+
+bodyHeader : RenderConfig -> msg -> String -> FilterSize -> Element msg
+bodyHeader renderConfig closeMsg label size =
+    let
+        { padding, fontSize, iconSize } =
+            headerProportions size
+    in
+    Element.row
+        [ Element.paddingEach padding
+        , Element.width fill
+        , Border.color Colors.gray300
+        , Border.widthEach { zeroPadding | bottom = 1 }
+        , Font.color Colors.navyBlue700
+        , Font.size fontSize
+        , Font.bold
+        ]
+        [ Element.text label
+        , bodyCloseIcon renderConfig closeMsg iconSize
+        ]
+
+
+bodyCloseIcon : RenderConfig -> msg -> Int -> Element msg
+bodyCloseIcon renderConfig closeMsg iconSize =
+    Icon.close "Discard"
+        |> Icon.withCustomSize iconSize
+        |> Icon.renderElement renderConfig
+        |> Element.el
+            (ARIA.toElementAttributes ARIA.roleButton
+                ++ [ Element.alignRight
+                   , Element.pointer
+                   , Events.onClick closeMsg
+                   , Element.onEnterPressed closeMsg
+                   , Element.tabIndex 0
+                   ]
+            )
+
+
+bodyButtons : RenderConfig -> List (Button msg) -> List (Element msg)
+bodyButtons renderConfig =
+    let
+        applier =
+            Button.withWidth Button.widthFull
+                >> Button.renderElement renderConfig
+    in
+    List.map applier
+
+
+bodySorting : RenderConfig -> Maybe (BodySorting msg) -> Element msg
+bodySorting renderConfig sorting =
+    case sorting of
+        Just {} ->
+            Element.column [ Element.width fill ]
+                []
+
+        Nothing ->
+            Element.none
+
+
+roundedBorders : Attribute msg
+roundedBorders =
+    Border.rounded 6

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -186,7 +186,6 @@ headerToElement renderConfig (Header { label, openMsg } common { sorting, applie
                                         , hasFocus = False
                                         }
                                     ++ [ Element.alignRight
-                                       , Border.width 2
                                        , Element.pointer
                                        , Element.onIndividualClick appliedData.discardMsg
                                        ]

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -176,17 +176,17 @@ headerToElement renderConfig (Header { label, openMsg } common { sorting, applie
 headerSortingIcon : RenderConfig -> Int -> Maybe SortingDirection -> Element msg
 headerSortingIcon renderConfig iconSize sorting =
     case sorting of
-        Just SortIncreasing ->
+        Just SortAscending ->
             RenderConfig.localeTerms renderConfig
-                |> (.tables >> .sorting >> .increase)
+                |> (.tables >> .sorting >> .ascending)
                 |> Icon.sortIncreasing
                 |> Icon.withCustomSize iconSize
                 |> Icon.renderElement renderConfig
                 |> Element.el [ Element.width shrink ]
 
-        Just SortDecreasing ->
+        Just SortDescending ->
             RenderConfig.localeTerms renderConfig
-                |> (.tables >> .sorting >> .decrease)
+                |> (.tables >> .sorting >> .descending)
                 |> Icon.sortDecreasing
                 |> Icon.withCustomSize iconSize
                 |> Icon.renderElement renderConfig

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -184,11 +184,7 @@ headerClearIcon renderConfig clearMsg iconSize =
 
 headerProportions :
     FilterSize
-    ->
-        { padding : RectangleSides
-        , fontSize : Int
-        , iconSize : Int
-        }
+    -> { fontSize : Int, iconSize : Int, padding : RectangleSides }
 headerProportions size =
     case size of
         Medium ->
@@ -349,79 +345,90 @@ bodyCloseIcon renderConfig closeMsg iconSize =
 bodySorting : RenderConfig -> FilterSize -> Maybe (BodySorting msg) -> Element msg
 bodySorting renderConfig size sorting =
     case sorting of
-        Just { smaller, larger, ascendingSortMsg, descendingSortMsg, clearSortMsg, applied } ->
+        Just sortingData ->
             let
-                { fontSize, iconSize } =
+                proportions =
                     bodySortingProportions size
 
                 terms =
                     RenderConfig.localeTerms renderConfig
-
-                backgroundColor direction =
-                    if applied == Just direction then
-                        Background.color Colors.navyBlue200
-
-                    else
-                        Colors.mainBackground
-
-                allowClearingMsg direction msg =
-                    if applied == Just direction then
-                        clearSortMsg
-
-                    else
-                        msg
-
-                sortAs direction label msg =
-                    Element.row
-                        [ Element.width fill
-                        , Font.color Colors.navyBlue700
-                        , Font.size fontSize
-                        , Font.medium
-                        , Element.paddingEach
-                            { top = 6, left = 12, right = 6, bottom = 6 }
-                        , Element.spacing 6
-                        , Border.color Colors.gray300
-                        , Border.widthEach { zeroPadding | bottom = 1 }
-                        , Events.onClick <| allowClearingMsg direction msg
-                        , Element.onEnterPressed <| allowClearingMsg direction msg
-                        , Element.tabIndex 0
-                        , backgroundColor direction
-                        , Element.pointer
-                        , Element.mouseOver
-                            [ Background.color Colors.gray300
-                            ]
-                        ]
-                        [ Element.paragraph []
-                            [ Element.text label
-                            , Element.text " ("
-                            , Element.text smaller
-                            , Element.text " - "
-                            , Element.text larger
-                            , Element.text ")"
-                            ]
-                        , sortingIcon renderConfig
-                            [ Element.alignRight
-                            ]
-                            iconSize
-                            (Just direction)
-                        ]
             in
             Element.column [ Element.width fill ]
-                [ sortAs SortAscending terms.tables.sorting.ascending ascendingSortMsg
-                , sortAs SortDescending terms.tables.sorting.descending descendingSortMsg
+                [ sortAs renderConfig
+                    SortAscending
+                    proportions
+                    sortingData
+                    terms.tables.sorting.ascending
+                    sortingData.ascendingSortMsg
+                , sortAs renderConfig
+                    SortDescending
+                    proportions
+                    sortingData
+                    terms.tables.sorting.descending
+                    sortingData.descendingSortMsg
                 ]
 
         Nothing ->
             Element.none
 
 
+sortAs :
+    RenderConfig
+    -> SortingDirection
+    -> { fontSize : Int, iconSize : Int, padding : RectangleSides }
+    -> BodySorting msg
+    -> String
+    -> msg
+    -> Element msg
+sortAs renderConfig direction { fontSize, iconSize } sortingData label msg =
+    let
+        ( backgroundColor, allowClearingMsg ) =
+            if sortingData.applied == Just direction then
+                ( Background.color Colors.navyBlue200
+                , sortingData.clearSortMsg
+                )
+
+            else
+                ( Colors.mainBackground, msg )
+    in
+    Element.row
+        [ Element.width fill
+        , Font.color Colors.navyBlue700
+        , Font.size fontSize
+        , Font.medium
+        , Element.paddingEach
+            { top = 6, left = 12, right = 6, bottom = 6 }
+        , Element.spacing 6
+        , Border.color Colors.gray300
+        , Border.widthEach { zeroPadding | bottom = 1 }
+        , Events.onClick <| allowClearingMsg
+        , Element.onEnterPressed <| allowClearingMsg
+        , Element.tabIndex 0
+        , backgroundColor
+        , Element.pointer
+        , Element.mouseOver
+            [ Background.color Colors.gray300
+            ]
+        ]
+        [ Element.paragraph []
+            [ Element.text label
+            , Element.text " ("
+            , Element.text sortingData.smaller
+            , Element.text " - "
+            , Element.text sortingData.larger
+            , Element.text ")"
+            ]
+        , sortingIcon renderConfig
+            [ Element.alignRight
+            ]
+            iconSize
+            (Just direction)
+        ]
+
+
 bodySortingProportions :
     FilterSize
-    ->
-        { padding : RectangleSides
-        , fontSize : Int
-        , iconSize : Int
-        }
+    -> { fontSize : Int, iconSize : Int, padding : RectangleSides }
 bodySortingProportions size =
     case size of
         Medium ->

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -179,12 +179,18 @@ headerToElement renderConfig (Header { label, openMsg } common { sorting, applie
                             |> Icon.withCustomSize iconSize
                             |> Icon.renderElement renderConfig
                             |> Element.el
-                                -- REVIEW: Add ARIA + Focus
-                                [ Element.alignRight
-                                , Border.width 2
-                                , Element.pointer
-                                , Element.onIndividualClick appliedData.discardMsg
-                                ]
+                                (ARIA.toElementAttributes ARIA.roleButton
+                                    ++ Focus.toElementAttributes
+                                        { onEnter = appliedData.discardMsg
+                                        , tabIndex = 0
+                                        , hasFocus = False
+                                        }
+                                    ++ [ Element.alignRight
+                                       , Border.width 2
+                                       , Element.pointer
+                                       , Element.onIndividualClick appliedData.discardMsg
+                                       ]
+                                )
                     , baseColor = Colors.navyBlue200
                     }
 

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -364,6 +364,13 @@ bodySorting renderConfig size sorting =
                     else
                         Colors.mainBackground
 
+                allowClearingMsg direction msg =
+                    if applied == Just direction then
+                        clearSortMsg
+
+                    else
+                        msg
+
                 sortAs direction label msg =
                     Element.row
                         [ Element.width fill
@@ -375,15 +382,16 @@ bodySorting renderConfig size sorting =
                         , Element.spacing 6
                         , Border.color Colors.gray300
                         , Border.widthEach { zeroPadding | bottom = 1 }
-                        , Events.onClick msg
-                        , Element.onEnterPressed msg
+                        , Events.onClick <| allowClearingMsg direction msg
+                        , Element.onEnterPressed <| allowClearingMsg direction msg
                         , Element.tabIndex 0
                         , backgroundColor direction
+                        , Element.pointer
                         , Element.mouseOver
                             [ Background.color Colors.gray300
                             ]
                         ]
-                        [ Element.paragraph [ Events.onClick msg ]
+                        [ Element.paragraph []
                             [ Element.text label
                             , Element.text " ("
                             , Element.text smaller

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -1,0 +1,205 @@
+module UI.Internal.Filter.View exposing (..)
+
+import Element exposing (Element, fill, shrink)
+import Element.Background as Background
+import Element.Border as Border
+import Element.Events as Events
+import Element.Font as Font
+import Html.Attributes as HtmlAttrs
+import UI.Button exposing (Button)
+import UI.Icon as Icon
+import UI.Internal.Colors as Colors
+import UI.Internal.Filter.Sorter exposing (SortingDirection(..))
+import UI.Internal.RenderConfig as RenderConfig
+import UI.RenderConfig exposing (RenderConfig)
+import UI.Text as Text
+import UI.Utils.ARIA as ARIA
+import UI.Utils.Focus as Focus
+
+
+type FilterSize
+    = ExtraSmall
+    | Medium
+
+
+type FilterWidth
+    = WidthFull
+    | WidthShrink
+
+
+type Header msg
+    = Header
+        { label : String, openMsg : msg }
+        CommonOptions
+        { sorting : Maybe SortingDirection
+        , applied : Maybe { preview : String, discardMsg : msg }
+        }
+
+
+type Body msg
+    = Body
+        { label : String, closeMsg : msg }
+        CommonOptions
+        { sorting :
+            Maybe
+                { smaller : String
+                , larger : String
+                , ascendingSortMsg : msg
+                , descendingSortMsg : msg
+                }
+        , options : List (Element msg)
+        , buttons : List (Button msg)
+        , closeMsg : msg
+        }
+
+
+type alias CommonOptions =
+    { width : FilterWidth
+    , size : FilterSize
+    }
+
+
+header : String -> msg -> Header msg
+header label openMsg =
+    Header
+        { label = label, openMsg = openMsg }
+        { width = WidthFull, size = Medium }
+        { sorting = Nothing, applied = Nothing }
+
+
+headerWithWidth : FilterWidth -> Header msg -> Header msg
+headerWithWidth width (Header prop common options) =
+    Header prop { common | width = width } options
+
+
+headerWithSize : FilterSize -> Header msg -> Header msg
+headerWithSize size (Header prop common options) =
+    Header prop { common | size = size } options
+
+
+headerWithSorting : Maybe SortingDirection -> Header msg -> Header msg
+headerWithSorting sorting (Header prop common options) =
+    Header prop common { options | sorting = sorting }
+
+
+headerWithApplied :
+    Maybe { preview : String, discardMsg : msg }
+    -> Header msg
+    -> Header msg
+headerWithApplied applied (Header prop common options) =
+    Header prop common { options | applied = applied }
+
+
+extraSmall : FilterSize
+extraSmall =
+    ExtraSmall
+
+
+headerToElement : RenderConfig -> Header msg -> Element msg
+headerToElement renderConfig (Header { label, openMsg } common { sorting, applied }) =
+    let
+        terms =
+            RenderConfig.localeTerms renderConfig
+
+        { padding, fontSize, iconSize } =
+            if common.size == Medium then
+                { padding = { left = 10, bottom = 7, top = 9, right = 12 }
+                , fontSize = 16
+                , iconSize = 20
+                }
+
+            else
+                { padding = { left = 8, bottom = 7, top = 7, right = 12 }
+                , fontSize = 12
+                , iconSize = 16
+                }
+
+        attrs =
+            ARIA.toElementAttributes ARIA.roleButton
+                ++ Focus.toElementAttributes
+                    { onEnter = openMsg
+                    , tabIndex = 0
+                    , hasFocus = False
+                    }
+                ++ [ Element.width <|
+                        if common.width == WidthFull then
+                            fill
+
+                        else
+                            shrink
+                   , Element.paddingEach padding
+                   , Element.spacing 8
+                   , Background.color baseColor
+                   , Border.width 2
+                   , Border.rounded 6
+                   , Border.color baseColor
+                   , Font.color Colors.navyBlue700
+                   , Font.size fontSize
+                   , Font.bold
+                   , Element.focused
+                        [ Border.color Colors.navyBlue600
+                        ]
+                   , Element.mouseOver
+                        [ Background.color Colors.gray300
+                        , Border.color Colors.gray300
+                        ]
+                   , Element.pointer
+                   , Events.onClick openMsg
+                   ]
+
+        body =
+            [ sortingIcon
+            , Element.text label
+            , preview
+            , rightIcon
+            ]
+
+        sortingIcon =
+            case sorting of
+                Just SortIncreasing ->
+                    terms.tables.sorting.increase
+                        |> Icon.sortIncreasing
+                        |> Icon.withCustomSize iconSize
+                        |> Icon.renderElement renderConfig
+                        |> Element.el [ Element.width shrink ]
+
+                Just SortDecreasing ->
+                    terms.tables.sorting.decrease
+                        |> Icon.sortDecreasing
+                        |> Icon.withCustomSize iconSize
+                        |> Icon.renderElement renderConfig
+
+                Nothing ->
+                    Element.none
+
+        { preview, rightIcon, baseColor } =
+            case applied of
+                Just appliedData ->
+                    { preview = Element.text <| "(" ++ appliedData.preview ++ ")"
+                    , rightIcon =
+                        Icon.close "Discard"
+                            |> Icon.withCustomSize iconSize
+                            |> Icon.renderElement renderConfig
+                            |> Element.el
+                                -- REVIEW: Add ARIA + Focus
+                                [ Element.alignRight
+                                , Element.focused
+                                    [ Border.color Colors.navyBlue600
+                                    ]
+                                , Element.pointer
+                                , Events.onClick appliedData.discardMsg
+                                ]
+                    , baseColor = Colors.navyBlue200
+                    }
+
+                Nothing ->
+                    { preview = Element.none
+                    , rightIcon =
+                        Icon.filter label
+                            |> Icon.withCustomSize iconSize
+                            |> Icon.renderElement renderConfig
+                            |> Element.el [ Element.alignRight ]
+                    , baseColor = Colors.gray200
+                    }
+    in
+    Element.row attrs body

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -3,17 +3,15 @@ module UI.Internal.Filter.View exposing (..)
 import Element exposing (Element, fill, shrink)
 import Element.Background as Background
 import Element.Border as Border
-import Element.Events as Events
 import Element.Font as Font
-import Html.Attributes as HtmlAttrs
 import UI.Button exposing (Button)
 import UI.Icon as Icon
 import UI.Internal.Colors as Colors
 import UI.Internal.Filter.Sorter exposing (SortingDirection(..))
 import UI.Internal.RenderConfig as RenderConfig
 import UI.RenderConfig exposing (RenderConfig)
-import UI.Text as Text
 import UI.Utils.ARIA as ARIA
+import UI.Utils.Element as Element
 import UI.Utils.Focus as Focus
 
 
@@ -24,7 +22,6 @@ type FilterSize
 
 type FilterWidth
     = WidthFull
-    | WidthShrink
 
 
 type Header msg
@@ -144,7 +141,7 @@ headerToElement renderConfig (Header { label, openMsg } common { sorting, applie
                         , Border.color Colors.gray300
                         ]
                    , Element.pointer
-                   , Events.onClick openMsg
+                   , Element.onIndividualClick openMsg
                    ]
 
         body =
@@ -168,6 +165,7 @@ headerToElement renderConfig (Header { label, openMsg } common { sorting, applie
                         |> Icon.sortDecreasing
                         |> Icon.withCustomSize iconSize
                         |> Icon.renderElement renderConfig
+                        |> Element.el [ Element.width shrink ]
 
                 Nothing ->
                     Element.none
@@ -183,11 +181,9 @@ headerToElement renderConfig (Header { label, openMsg } common { sorting, applie
                             |> Element.el
                                 -- REVIEW: Add ARIA + Focus
                                 [ Element.alignRight
-                                , Element.focused
-                                    [ Border.color Colors.navyBlue600
-                                    ]
+                                , Border.width 2
                                 , Element.pointer
-                                , Events.onClick appliedData.discardMsg
+                                , Element.onIndividualClick appliedData.discardMsg
                                 ]
                     , baseColor = Colors.navyBlue200
                     }

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -31,7 +31,7 @@ import UI.Icon as Icon
 import UI.Internal.Colors as Colors
 import UI.Internal.Filter.Sorter exposing (SortingDirection(..))
 import UI.Internal.RenderConfig as RenderConfig
-import UI.Internal.Utils.Element as Element
+import UI.Internal.Utils.Element as Element exposing (overlayZIndex)
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Size as Size
 import UI.Utils.ARIA as ARIA
@@ -266,7 +266,7 @@ bodyToElement renderConfig (Body { label, closeMsg } common { sorting, rows, but
                 Element.width common.width
 
         attrs =
-            [ Element.zIndex 9
+            [ Element.zIndex (overlayZIndex + 1)
             , Element.alignTop
             , Colors.mainBackground
             , Border.shadow

--- a/src/UI/Internal/Tables/Filters.elm
+++ b/src/UI/Internal/Tables/Filters.elm
@@ -1,39 +1,4 @@
-module UI.Internal.Tables.Filters exposing
-    ( Editable
-    , Filter(..)
-    , FilterConfig
-    , Filters
-    , Msg(..)
-    , MultiTextFilterConfig
-    , PeriodDateFilterConfig
-    , RangeDateFilterConfig
-    , RemoteMessages
-    , SelectFilterConfig
-    , SingleDateFilterConfig
-    , SingleTextFilterConfig
-    , Strategy(..)
-    , dateSeparator
-    , editableWithDefault
-    , empty
-    , filterGet
-    , filtersReduce
-    , isApplied
-    , isEdited
-    , itemsApplyFilters
-    , multiTextLocal
-    , multiTextRemote
-    , periodDateLocal
-    , periodDateRemote
-    , rangeDateLocal
-    , rangeDateRemote
-    , selectLocal
-    , selectRemote
-    , singleDateLocal
-    , singleDateRemote
-    , singleTextLocal
-    , singleTextRemote
-    , update
-    )
+module UI.Internal.Tables.Filters exposing (..)
 
 import Array exposing (Array)
 import Time exposing (Posix)
@@ -41,6 +6,7 @@ import UI.Effect as Effect exposing (Effect)
 import UI.Internal.Analytics as Analytics
 import UI.Internal.Basics exposing (flip, maybeNotThen)
 import UI.Internal.DateInput as DateInput exposing (DateInput(..), PeriodComparison(..), PeriodDate, RangeDate)
+import UI.Internal.Filter.Model exposing (..)
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Utils.TypeNumbers as T
 
@@ -72,45 +38,6 @@ itemsApplyFilters filters items =
 
 
 
--- Internal Type
-
-
-type Filter msg item
-    = SingleTextFilter (SingleTextFilterConfig msg item)
-    | MultiTextFilter (MultiTextFilterConfig msg item)
-    | SingleDateFilter (SingleDateFilterConfig msg item)
-    | RangeDateFilter (RangeDateFilterConfig msg item)
-    | PeriodDateFilter (PeriodDateFilterConfig msg item)
-    | SelectFilter (List String) (SelectFilterConfig msg item)
-
-
-type alias Editable value =
-    { current : Maybe value
-    , applied : Maybe value
-    }
-
-
-type alias FilterConfig msg value item =
-    { editable : Editable value
-    , strategy : Strategy msg value item
-    }
-
-
-type Strategy msg value item
-    = Local (item -> value -> Bool)
-    | Remote (RemoteMessages msg value)
-
-
-type alias RemoteMessages msg value =
-    { applyMsg : value -> msg, clearMsg : msg }
-
-
-configSetEditable : FilterConfig msg value item -> Editable value -> FilterConfig msg value item
-configSetEditable config newEditable =
-    { config | editable = newEditable }
-
-
-
 -- Filters
 
 
@@ -135,529 +62,6 @@ push newValue model =
 
 
 
--- Editable
-
-
-editableEmpty : Editable something
-editableEmpty =
-    { current = Nothing, applied = Nothing }
-
-
-editableWithDefault : data -> Editable data -> data
-editableWithDefault default { current, applied } =
-    current
-        |> maybeNotThen applied
-        |> Maybe.withDefault default
-
-
-editableApply : Editable data -> Editable data
-editableApply { current } =
-    { current = Nothing, applied = current }
-
-
-
--- Strategy
-
-
-strategyLocal : (item -> value -> Bool) -> Strategy msg value item
-strategyLocal isKept =
-    Local isKept
-
-
-strategyRemote : RemoteMessages msg value -> Strategy msg value item
-strategyRemote messages =
-    Remote messages
-
-
-
--- SingleText
-
-
-type alias SingleTextFilterConfig msg item =
-    FilterConfig msg String item
-
-
-singleTextLocal :
-    Maybe String
-    -> (item -> String)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-singleTextLocal initValue getStr accu =
-    let
-        applier item current =
-            getStr item
-                |> String.toLower
-                |> String.contains (String.toLower current)
-    in
-    { editable = { applied = initValue, current = Nothing }
-    , strategy = strategyLocal applier
-    }
-        |> SingleTextFilter
-        |> flip push accu
-
-
-singleTextRemote :
-    Maybe String
-    -> (Maybe String -> msg)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-singleTextRemote initValue applyMsg accu =
-    { editable = { applied = initValue, current = Nothing }
-    , strategy =
-        strategyRemote
-            { applyMsg = Just >> applyMsg
-            , clearMsg = applyMsg Nothing
-            }
-    }
-        |> SingleTextFilter
-        |> flip push accu
-
-
-singleTextEdit : Int -> String -> Filters msg item columns -> Filters msg item columns
-singleTextEdit column value model =
-    case get column model of
-        Just (SingleTextFilter config) ->
-            config.editable
-                |> editableSetCurrent value
-                |> configSetEditable config
-                |> SingleTextFilter
-                |> flip (set column) model
-
-        _ ->
-            model
-
-
-
--- MultiText
-
-
-type alias MultiTextFilterConfig msg item =
-    FilterConfig msg (Array String) item
-
-
-multiTextLocal :
-    List String
-    -> (item -> String)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-multiTextLocal initValue getStr accu =
-    let
-        applier item current =
-            getStr item
-                |> String.toLower
-                |> String.contains (String.toLower current)
-
-        strategy item valueArray =
-            valueArray
-                |> Array.toList
-                |> List.any (applier item)
-    in
-    { editable = { applied = listToMaybeArray initValue, current = Nothing }
-    , strategy = strategyLocal strategy
-    }
-        |> MultiTextFilter
-        |> flip push accu
-
-
-multiTextRemote :
-    List String
-    -> (List String -> msg)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-multiTextRemote initValue applyMsg accu =
-    { editable = { applied = listToMaybeArray initValue, current = Nothing }
-    , strategy =
-        strategyRemote
-            { applyMsg = Array.toList >> applyMsg
-            , clearMsg = applyMsg []
-            }
-    }
-        |> MultiTextFilter
-        |> flip push accu
-
-
-multiTextEdit : Int -> Int -> String -> Filters msg item columns -> Filters msg item columns
-multiTextEdit column field value model =
-    case get column model of
-        Just (MultiTextFilter config) ->
-            config.editable
-                |> editableWithDefault Array.empty
-                |> flexibleArray field value
-                |> flip editableSetCurrent config.editable
-                |> configSetEditable config
-                |> MultiTextFilter
-                |> flip (set column) model
-
-        _ ->
-            model
-
-
-listToMaybeArray : List a -> Maybe (Array a)
-listToMaybeArray list =
-    if list == [] then
-        Nothing
-
-    else
-        Just <| Array.fromList list
-
-
-flexibleArray : Int -> String -> Array String -> Array String
-flexibleArray index newValue array =
-    if Array.length array == index then
-        if String.isEmpty newValue then
-            array
-
-        else
-            Array.push newValue array
-
-    else
-        array
-            |> Array.set index newValue
-            |> Array.filter (not << String.isEmpty)
-
-
-
--- SingleDate
-
-
-type alias SingleDateFilterConfig msg item =
-    FilterConfig msg DateInput item
-
-
-singleDateLocal :
-    Time.Zone
-    -> Maybe Posix
-    -> (item -> Posix)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-singleDateLocal timeZone initValue getPosix accu =
-    let
-        compare posix current =
-            DateInput.isPosixEqual current timeZone posix
-
-        applier item current =
-            compare (getPosix item) current
-    in
-    { editable = { applied = Maybe.map (DateInput.fromPosix timeZone) initValue, current = Nothing }
-    , strategy = strategyLocal applier
-    }
-        |> SingleDateFilter
-        |> flip push accu
-
-
-singleDateRemote :
-    Time.Zone
-    -> Maybe Posix
-    -> (Maybe DateInput -> msg)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-singleDateRemote timeZone initValue applyMsg accu =
-    { editable = { applied = Maybe.map (DateInput.fromPosix timeZone) initValue, current = Nothing }
-    , strategy =
-        strategyRemote
-            { applyMsg = Just >> applyMsg
-            , clearMsg = applyMsg Nothing
-            }
-    }
-        |> SingleDateFilter
-        |> flip push accu
-
-
-singleDateEdit : Int -> String -> Filters msg item columns -> Filters msg item columns
-singleDateEdit column value model =
-    case get column model of
-        Just (SingleDateFilter config) ->
-            config.editable
-                |> editableSetCurrent (DateInput.parseDD_MM_YYYY dateSeparator value)
-                |> configSetEditable config
-                |> SingleDateFilter
-                |> flip (set column) model
-
-        _ ->
-            model
-
-
-
--- RangeDate
-
-
-type alias RangeDateFilterConfig msg item =
-    FilterConfig msg RangeDate item
-
-
-rangeDateLocal :
-    Time.Zone
-    -> Maybe Posix
-    -> Maybe Posix
-    -> (item -> Posix)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-rangeDateLocal timeZone fromInit toInit getPosix accu =
-    let
-        compare posix { from, to } =
-            DateInput.isPosixBetween timeZone posix from to
-
-        applier item current =
-            compare (getPosix item) current
-    in
-    { editable = { applied = rangeDateInit timeZone fromInit toInit, current = Nothing }
-    , strategy = strategyLocal applier
-    }
-        |> RangeDateFilter
-        |> flip push accu
-
-
-rangeDateRemote :
-    Time.Zone
-    -> Maybe Posix
-    -> Maybe Posix
-    -> (Maybe RangeDate -> msg)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-rangeDateRemote timeZone fromInit toInit applyMsg accu =
-    { editable = { applied = rangeDateInit timeZone fromInit toInit, current = Nothing }
-    , strategy =
-        strategyRemote
-            { applyMsg = Just >> applyMsg
-            , clearMsg = applyMsg Nothing
-            }
-    }
-        |> RangeDateFilter
-        |> flip push accu
-
-
-rangeDateInit : Time.Zone -> Maybe Posix -> Maybe Posix -> Maybe RangeDate
-rangeDateInit timeZone fromInit toInit =
-    case ( fromInit, toInit ) of
-        ( Just fromPosix, Just toPosix ) ->
-            Just { from = DateInput.fromPosix timeZone fromPosix, to = DateInput.fromPosix timeZone toPosix }
-
-        ( Just fromPosix, Nothing ) ->
-            Just { from = DateInput.fromPosix timeZone fromPosix, to = DateInvalid "" }
-
-        ( Nothing, Just toPosix ) ->
-            Just { from = DateInvalid "", to = DateInput.fromPosix timeZone toPosix }
-
-        ( Nothing, Nothing ) ->
-            Nothing
-
-
-rangeDateFromEdit : Int -> String -> Filters msg item columns -> Filters msg item columns
-rangeDateFromEdit column value model =
-    case get column model of
-        Just (RangeDateFilter config) ->
-            config.editable
-                |> editableMapCurrent
-                    (\maybeCurrent ->
-                        { from = DateInput.parseDD_MM_YYYY dateSeparator value
-                        , to =
-                            maybeCurrent
-                                |> Maybe.map .to
-                                |> Maybe.withDefault (DateInvalid "")
-                        }
-                    )
-                |> configSetEditable config
-                |> RangeDateFilter
-                |> flip (set column) model
-
-        _ ->
-            model
-
-
-rangeDateToEdit : Int -> String -> Filters msg item columns -> Filters msg item columns
-rangeDateToEdit column value model =
-    case get column model of
-        Just (RangeDateFilter config) ->
-            config.editable
-                |> editableMapCurrent
-                    (\maybeCurrent ->
-                        { from =
-                            maybeCurrent
-                                |> Maybe.map .from
-                                |> Maybe.withDefault (DateInvalid "")
-                        , to = DateInput.parseDD_MM_YYYY dateSeparator value
-                        }
-                    )
-                |> configSetEditable config
-                |> RangeDateFilter
-                |> flip (set column) model
-
-        _ ->
-            model
-
-
-
--- PeriodDate
-
-
-type alias PeriodDateFilterConfig msg item =
-    FilterConfig msg PeriodDate item
-
-
-periodDateInit : Time.Zone -> Maybe Posix -> Maybe PeriodComparison -> Maybe PeriodDate
-periodDateInit timeZone posixInit periodInit =
-    case ( posixInit, periodInit ) of
-        ( Just posix, Just period ) ->
-            Just { date = DateInput.fromPosix timeZone posix, comparison = period }
-
-        ( Just posix, Nothing ) ->
-            Just { date = DateInput.fromPosix timeZone posix, comparison = On }
-
-        ( Nothing, Just period ) ->
-            Just { date = DateInvalid "", comparison = period }
-
-        ( Nothing, Nothing ) ->
-            Nothing
-
-
-periodDateLocal :
-    Time.Zone
-    -> Maybe Posix
-    -> Maybe PeriodComparison
-    -> (item -> Posix)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-periodDateLocal timeZone posixInit periodInit getPosix accu =
-    let
-        compare posix { date, comparison } =
-            case comparison of
-                On ->
-                    DateInput.isPosixEqual date timeZone posix
-
-                Before ->
-                    DateInput.isPosixBefore date timeZone posix
-
-                After ->
-                    DateInput.isPosixAfter date timeZone posix
-
-        applier item current =
-            compare (getPosix item) current
-    in
-    { editable = { applied = periodDateInit timeZone posixInit periodInit, current = Nothing }
-    , strategy = strategyLocal applier
-    }
-        |> PeriodDateFilter
-        |> flip push accu
-
-
-periodDateRemote :
-    Time.Zone
-    -> Maybe Posix
-    -> Maybe PeriodComparison
-    -> (Maybe PeriodDate -> msg)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-periodDateRemote timeZone posixInit periodInit applyMsg accu =
-    { editable = { applied = periodDateInit timeZone posixInit periodInit, current = Nothing }
-    , strategy =
-        strategyRemote
-            { applyMsg = Just >> applyMsg
-            , clearMsg = applyMsg Nothing
-            }
-    }
-        |> PeriodDateFilter
-        |> flip push accu
-
-
-periodDateEdit : Int -> String -> Filters msg item columns -> Filters msg item columns
-periodDateEdit column value model =
-    case get column model of
-        Just (PeriodDateFilter config) ->
-            config.editable
-                |> editableMapCurrent
-                    (\maybeCurrent ->
-                        { date = DateInput.parseDD_MM_YYYY dateSeparator value
-                        , comparison =
-                            maybeCurrent
-                                |> Maybe.map .comparison
-                                |> Maybe.withDefault On
-                        }
-                    )
-                |> configSetEditable config
-                |> PeriodDateFilter
-                |> flip (set column) model
-
-        _ ->
-            model
-
-
-periodDateComparisonEdit : Int -> PeriodComparison -> Filters msg item columns -> Filters msg item columns
-periodDateComparisonEdit column value model =
-    case get column model of
-        Just (PeriodDateFilter config) ->
-            config.editable
-                |> editableMapCurrent
-                    (\maybeCurrent ->
-                        { date =
-                            maybeCurrent
-                                |> Maybe.map .date
-                                |> Maybe.withDefault (DateInvalid "")
-                        , comparison = value
-                        }
-                    )
-                |> configSetEditable config
-                |> PeriodDateFilter
-                |> flip (set column) model
-
-        _ ->
-            model
-
-
-
--- SelectFilter
-
-
-type alias SelectFilterConfig msg item =
-    FilterConfig msg Int item
-
-
-selectLocal :
-    List String
-    -> Maybe Int
-    -> (item -> Int -> Bool)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-selectLocal list initValue filter accu =
-    { editable = { applied = initValue, current = Nothing }
-    , strategy = strategyLocal filter
-    }
-        |> SelectFilter list
-        |> flip push accu
-
-
-selectRemote :
-    List String
-    -> Maybe Int
-    -> (Maybe Int -> msg)
-    -> Filters msg item columns
-    -> Filters msg item (T.Increase columns)
-selectRemote list initValue applyMsg accu =
-    { editable = { applied = initValue, current = Nothing }
-    , strategy =
-        strategyRemote
-            { applyMsg = Just >> applyMsg
-            , clearMsg = applyMsg Nothing
-            }
-    }
-        |> SelectFilter list
-        |> flip push accu
-
-
-selectEdit : Int -> Int -> Filters msg item columns -> Filters msg item columns
-selectEdit column value model =
-    case get column model of
-        Just (SelectFilter list config) ->
-            config.editable
-                |> editableSetCurrent value
-                |> configSetEditable config
-                |> SelectFilter list
-                |> flip (set column) model
-
-        _ ->
-            model
-
-
-
 -- Update
 
 
@@ -665,28 +69,28 @@ update : Msg -> Filters msg item columns -> ( Filters msg item columns, Effect m
 update msg model =
     case msg of
         EditSingleText { column, value } ->
-            ( singleTextEdit column value model, Effect.none )
+            ( columnEdit singleTextEdit column value model, Effect.none )
 
         EditMultiText { column, field, value } ->
-            ( multiTextEdit column field value model, Effect.none )
+            ( columnEdit (multiTextEdit field) column value model, Effect.none )
 
         EditSingleDate { column, value } ->
-            ( singleDateEdit column value model, Effect.none )
+            ( columnEdit singleDateEdit column value model, Effect.none )
 
         EditRangeFromDate { column, value } ->
-            ( rangeDateFromEdit column value model, Effect.none )
+            ( columnEdit rangeDateFromEdit column value model, Effect.none )
 
         EditRangeToDate { column, value } ->
-            ( rangeDateToEdit column value model, Effect.none )
+            ( columnEdit rangeDateToEdit column value model, Effect.none )
 
         EditPeriodDate { column, value } ->
-            ( periodDateEdit column value model, Effect.none )
+            ( columnEdit periodDateEdit column value model, Effect.none )
 
         EditPeriodComparison { column, value } ->
-            ( periodDateComparisonEdit column value model, Effect.none )
+            ( columnEdit periodDateComparisonEdit column value model, Effect.none )
 
         EditSelect { column, value } ->
-            ( selectEdit column value model, Effect.none )
+            ( columnEdit selectEdit column value model, Effect.none )
 
         Apply column ->
             applyFilter column model
@@ -695,6 +99,22 @@ update msg model =
         Clear column ->
             filterClear column model
                 |> withClearAnalytics column
+
+
+columnEdit :
+    (value -> Filter msg item -> Filter msg item)
+    -> Int
+    -> value
+    -> Filters msg item columns
+    -> Filters msg item columns
+columnEdit applier column value model =
+    case get column model of
+        Just filter ->
+            applier value filter
+                |> flip (set column) model
+
+        Nothing ->
+            model
 
 
 dispatchApply : Strategy msg value item -> value -> Filters msg item columns -> ( Filters msg item columns, Effect msg )
@@ -840,96 +260,6 @@ filterClear column model =
             ( model, Effect.none )
 
 
-editableSetCurrent : value -> Editable value -> Editable value
-editableSetCurrent new old =
-    { old | current = Just new }
-
-
-editableMapCurrent : (Maybe value -> value) -> Editable value -> Editable value
-editableMapCurrent applier old =
-    { old | current = Just <| applier <| maybeNotThen old.applied <| old.current }
-
-
-
--- Get Filters
-
-
-isEdited : Filter msg item -> Bool
-isEdited filter =
-    case filter of
-        SingleTextFilter { editable } ->
-            editable.current /= Nothing
-
-        MultiTextFilter { editable } ->
-            editable.current /= Nothing
-
-        SingleDateFilter { editable } ->
-            editable.current /= Nothing
-
-        RangeDateFilter { editable } ->
-            editable.current /= Nothing
-
-        PeriodDateFilter { editable } ->
-            editable.current /= Nothing
-
-        SelectFilter _ { editable } ->
-            editable.current /= Nothing
-
-
-isApplied : Filter msg item -> Bool
-isApplied filter =
-    case filter of
-        SingleTextFilter { editable } ->
-            editable.applied /= Nothing
-
-        MultiTextFilter { editable } ->
-            editable.applied /= Nothing
-
-        SingleDateFilter { editable } ->
-            editable.applied /= Nothing
-
-        RangeDateFilter { editable } ->
-            editable.applied /= Nothing
-
-        PeriodDateFilter { editable } ->
-            editable.applied /= Nothing
-
-        SelectFilter _ { editable } ->
-            editable.applied /= Nothing
-
-
-localAppliedMap : FilterConfig msg value item -> Maybe (item -> Bool)
-localAppliedMap { editable, strategy } =
-    case strategy of
-        Local applier ->
-            Maybe.map (flip applier) editable.applied
-
-        Remote _ ->
-            Nothing
-
-
-filterGet : Filter msg item -> Maybe (item -> Bool)
-filterGet filter =
-    case filter of
-        SingleTextFilter config ->
-            localAppliedMap config
-
-        MultiTextFilter config ->
-            localAppliedMap config
-
-        SingleDateFilter config ->
-            localAppliedMap config
-
-        RangeDateFilter config ->
-            localAppliedMap config
-
-        PeriodDateFilter config ->
-            localAppliedMap config
-
-        SelectFilter _ config ->
-            localAppliedMap config
-
-
 
 -- Filters combination
 
@@ -937,12 +267,3 @@ filterGet filter =
 filtersReduce : (item -> Bool) -> (item -> Bool) -> (item -> Bool)
 filtersReduce new old =
     \item -> new item && old item
-
-
-
--- Constant
-
-
-dateSeparator : String
-dateSeparator =
-    "/"

--- a/src/UI/Internal/Tables/Filters.elm
+++ b/src/UI/Internal/Tables/Filters.elm
@@ -1,11 +1,9 @@
 module UI.Internal.Tables.Filters exposing (..)
 
-import Array exposing (Array)
-import Time exposing (Posix)
 import UI.Effect as Effect exposing (Effect)
 import UI.Internal.Analytics as Analytics
-import UI.Internal.Basics exposing (flip, maybeNotThen)
-import UI.Internal.DateInput as DateInput exposing (DateInput(..), PeriodComparison(..), PeriodDate, RangeDate)
+import UI.Internal.Basics exposing (flip)
+import UI.Internal.DateInput exposing (PeriodComparison)
 import UI.Internal.Filter.Model exposing (..)
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Utils.TypeNumbers as T

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -111,11 +111,9 @@ header renderConfig filter sorting config =
             |> FilterV2.headerWithSorting
                 (Maybe.andThen identity sorting)
             |> FilterV2.headerWithApplied
-                (if Filter.isApplied filter then
-                    Just { preview = "1", clearMsg = clearMsg }
-
-                 else
-                    Nothing
+                (Maybe.map
+                    (\i -> { preview = String.fromInt i, clearMsg = clearMsg })
+                    (Filter.appliedLength filter)
                 )
             |> FilterV2.headerToElement renderConfig
 

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -3,8 +3,9 @@ module UI.Internal.Tables.FiltersView exposing (Config, header, headerSelectTogg
 -- WARNING: Don't use any other Size.* beyond "contextSize"
 
 import Array exposing (Array)
-import Element exposing (Attribute, Element, px)
+import Element exposing (Attribute, Element, fill, minimum, px)
 import Element.Background as Background
+import UI.Button as Button
 import UI.Icon as Icon
 import UI.Internal.Basics exposing (maybeNotThen)
 import UI.Internal.Colors as Colors
@@ -13,7 +14,7 @@ import UI.Internal.Filter.Model as Filter exposing (Filter)
 import UI.Internal.Filter.Sorter exposing (SortingDirection(..))
 import UI.Internal.Filter.View as FilterV2
 import UI.Internal.Primitives as Primitives
-import UI.Internal.RenderConfig exposing (localeTerms)
+import UI.Internal.RenderConfig as RenderConfig exposing (localeTerms)
 import UI.Internal.Size as Size exposing (Size)
 import UI.Internal.Tables.Filters as Filters
 import UI.Internal.Tables.Sorters as Sorters
@@ -54,6 +55,9 @@ header renderConfig filter sorting config =
             sortMsg =
                 Sorters.SetSorting config.index >> config.fromSortersMsg
 
+            terms =
+                RenderConfig.localeTerms renderConfig
+
             filterRender renderer editable =
                 FilterV2.body
                     config.label
@@ -69,6 +73,15 @@ header renderConfig filter sorting config =
                         , clearSortMsg = config.fromSortersMsg Sorters.ClearSorting
                         , applied = Maybe.andThen identity sorting
                         }
+                    |> FilterV2.bodyWithButtons
+                        [ terms.filters.apply
+                            |> Button.fromLabel
+                            |> Button.cmd applyMsg Button.primary
+                        , terms.filters.clear
+                            |> Button.fromLabel
+                            |> Button.cmd applyMsg Button.danger
+                        ]
+                    |> FilterV2.bodyWithWidth (fill |> minimum 180)
                     |> FilterV2.bodyToElement renderConfig
         in
         case filter of

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -129,61 +129,26 @@ header renderConfig filter sorting config =
 
 headerSelectToggle : RenderConfig -> msg -> Element msg
 headerSelectToggle renderConfig toggleMsg =
+    let
+        headerAttrs =
+            Element.onIndividualClick toggleMsg
+                :: Primitives.roundedBorders contextSize
+                :: Element.width Element.fill
+                :: Element.padding ((34 - 16) // 2)
+                :: Element.spacing 8
+                :: Element.pointer
+                :: Background.color Colors.gray200
+                :: Element.mouseOver [ Background.color Colors.navyBlue200 ]
+                :: Element.colorTransition 100
+                ++ ARIA.toElementAttributes ARIA.roleButton
+    in
     (localeTerms renderConfig |> .tables |> .selectAll)
         |> Icon.check
         |> Icon.withSize contextSize
         |> Icon.renderElement renderConfig
-        |> Element.el
-            (Element.onIndividualClick toggleMsg
-                :: headerAttrs False
-            )
+        |> Element.el headerAttrs
         |> Element.el
             [ Element.width (px 32) ]
-
-
-
--- Mostly ripped from Button with Size.Small and WidthFull
-
-
-headerPadX : Int
-headerPadX =
-    (36 - 16) // 2
-
-
-headerAttrs : Bool -> List (Attribute msg)
-headerAttrs isApplied =
-    let
-        baseHeight =
-            if isApplied then
-                24
-
-            else
-                16
-
-        paddingXY =
-            Element.paddingXY
-                headerPadX
-                ((36 - baseHeight) // 2)
-
-        workingTheme =
-            if isApplied then
-                [ Background.color Colors.navyBlue700 ]
-
-            else
-                Background.color
-                    Colors.gray200
-                    :: Element.mouseOver [ Background.color Colors.navyBlue200 ]
-                    :: Element.colorTransition 100
-    in
-    Primitives.roundedBorders
-        contextSize
-        :: Element.width Element.fill
-        :: paddingXY
-        :: Element.spacing 8
-        :: Element.pointer
-        :: (ARIA.toElementAttributes ARIA.roleButton
-                ++ workingTheme
-           )
 
 
 
@@ -196,7 +161,6 @@ contextSize =
 
 
 
--- Editing
 -- Specifics
 
 

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -3,14 +3,10 @@ module UI.Internal.Tables.FiltersView exposing (Config, header, headerSelectTogg
 -- WARNING: Don't use any other Size.* beyond "contextSize"
 
 import Array exposing (Array)
-import Element exposing (Attribute, Element, fill, minimum, px, shrink)
+import Element exposing (Attribute, Element, px)
 import Element.Background as Background
-import Element.Border as Border
-import Element.Events as Events
-import Element.Font as Font
-import UI.Button as Button
 import UI.Icon as Icon
-import UI.Internal.Basics exposing (maybeNotThen, prependIf)
+import UI.Internal.Basics exposing (maybeNotThen)
 import UI.Internal.Colors as Colors
 import UI.Internal.DateInput as DateInput exposing (DateInput(..), PeriodComparison(..), PeriodDate, RangeDate)
 import UI.Internal.Filter.Model as Filter exposing (Filter)
@@ -21,15 +17,11 @@ import UI.Internal.RenderConfig exposing (localeTerms)
 import UI.Internal.Size as Size exposing (Size)
 import UI.Internal.Tables.Filters as Filters
 import UI.Internal.Tables.Sorters as Sorters
-import UI.Internal.Utils.Element exposing (overlay, tuplesToStyles, zIndex)
-import UI.Palette as Palette exposing (brightnessMiddle, tonePrimary)
 import UI.Radio as Radio
 import UI.RenderConfig exposing (RenderConfig)
-import UI.Size as Size
-import UI.Text as Text
 import UI.TextField as TextField exposing (TextField)
 import UI.Utils.ARIA as ARIA
-import UI.Utils.Element as Element exposing (zeroPadding)
+import UI.Utils.Element as Element
 
 
 type alias Config msg =
@@ -53,15 +45,32 @@ header renderConfig filter sorting config =
     let
         clearMsg =
             config.fromFiltersMsg <| Filters.Clear config.index
-
-        applyMsg =
-            config.fromFiltersMsg <| Filters.Apply config.index
-
-        filterRender renderer editable =
-            renderer renderConfig applyMsg config editable
-                |> dialog renderConfig config filter sorting clearMsg applyMsg
     in
     if config.isOpen then
+        let
+            applyMsg =
+                config.fromFiltersMsg <| Filters.Apply config.index
+
+            sortMsg =
+                Sorters.SetSorting config.index >> config.fromSortersMsg
+
+            filterRender renderer editable =
+                FilterV2.body
+                    config.label
+                    config.discardMsg
+                    |> FilterV2.bodyWithSize FilterV2.sizeExtraSmall
+                    |> FilterV2.bodyWithRows
+                        (renderer renderConfig applyMsg config editable)
+                    |> FilterV2.bodyWithSorting
+                        { smaller = "A"
+                        , larger = "Z"
+                        , ascendingSortMsg = sortMsg SortIncreasing
+                        , descendingSortMsg = sortMsg SortDecreasing
+                        , clearSortMsg = config.fromSortersMsg Sorters.ClearSorting
+                        , applied = Maybe.andThen identity sorting
+                        }
+                    |> FilterV2.bodyToElement renderConfig
+        in
         case filter of
             Filter.SingleTextFilter { editable } ->
                 filterRender singleTextFilterRender editable
@@ -79,19 +88,18 @@ header renderConfig filter sorting config =
                 filterRender periodDateFilterRender editable
 
             Filter.SelectFilter list { editable } ->
-                selectFilterRender renderConfig config list editable
-                    |> dialog renderConfig config filter sorting clearMsg applyMsg
+                filterRender (selectFilterRender list) editable
 
     else
         FilterV2.header
             config.label
             config.openMsg
-            |> FilterV2.headerWithSize FilterV2.extraSmall
+            |> FilterV2.headerWithSize FilterV2.sizeExtraSmall
             |> FilterV2.headerWithSorting
                 (Maybe.andThen identity sorting)
             |> FilterV2.headerWithApplied
                 (if Filter.isApplied filter then
-                    Just { preview = "1", discardMsg = clearMsg }
+                    Just { preview = "1", clearMsg = clearMsg }
 
                  else
                     Nothing
@@ -166,11 +174,6 @@ headerAttrs isApplied =
 -- Standard size used for headers
 
 
-textSize : Int
-textSize =
-    12
-
-
 contextSize : Size
 contextSize =
     Size.ExtraSmall
@@ -178,177 +181,6 @@ contextSize =
 
 
 -- Editing
-
-
-filterEditingButton : RenderConfig -> msg -> msg -> Bool -> Bool -> Element msg
-filterEditingButton renderConfig applyMsg clearMsg applied current =
-    let
-        filtersTerms =
-            renderConfig |> localeTerms >> .filters
-
-        clearBtn =
-            Button.fromLabel filtersTerms.clear
-                |> Button.cmd clearMsg Button.danger
-                |> Button.withSize contextSize
-
-        applyBtn =
-            Button.fromLabel filtersTerms.apply
-                |> Button.cmd applyMsg Button.primary
-                |> Button.withSize contextSize
-
-        disabledBtn =
-            applyBtn |> Button.withDisabledIf True
-    in
-    case ( applied, current ) of
-        ( _, True ) ->
-            [ applyBtn, clearBtn ]
-                |> List.map (Button.renderElement renderConfig)
-                |> Element.row [ Element.spacing 8 ]
-
-        ( True, False ) ->
-            Button.renderElement renderConfig clearBtn
-
-        ( False, False ) ->
-            Button.renderElement renderConfig disabledBtn
-
-
-dialogHeader : RenderConfig -> msg -> String -> Element msg
-dialogHeader renderConfig discardMsg label =
-    Element.row
-        [ Element.paddingEach { top = 10, left = headerPadX, right = 10, bottom = 9 }
-        , Element.width fill
-        , Border.color Colors.gray300
-        , Border.widthEach { zeroPadding | bottom = 1 }
-        ]
-        [ filteredHeaderLabel label
-        , dialogClose renderConfig discardMsg
-        ]
-
-
-filteredHeaderLabel : String -> Element msg
-filteredHeaderLabel label =
-    label
-        |> Element.text
-        |> Element.el [ Font.bold, Font.size textSize ]
-
-
-dialogClose : RenderConfig -> msg -> Element msg
-dialogClose renderConfig message =
-    (renderConfig |> localeTerms >> .filters >> .close)
-        |> Icon.close
-        |> Icon.withColor (Palette.color Palette.toneGray Palette.brightnessLight)
-        |> Icon.withSize contextSize
-        |> Icon.renderElement renderConfig
-        |> Element.el
-            (ARIA.toElementAttributes ARIA.roleButton
-                ++ [ Events.onClick message
-                   , Element.pointer
-                   , Element.centerY
-                   , Element.height shrink
-                   , Element.alignRight
-                   ]
-            )
-
-
-dialog :
-    RenderConfig
-    -> Config msg
-    -> Filter msg item
-    -> Sorters.ColumnStatus
-    -> msg
-    -> msg
-    -> Element msg
-    -> Element msg
-dialog renderConfig config filter sorter clearMsg applyMsg content =
-    let
-        applied =
-            Filter.isApplied filter
-
-        current =
-            Filter.isEdited filter
-    in
-    overlay config.discardMsg <|
-        Element.column
-            [ zIndex 9
-            , Element.alignTop
-            , Colors.mainBackground
-            , Primitives.defaultRoundedBorders
-            , tuplesToStyles ( "min-width", "100%" )
-            , tuplesToStyles ( "width", "min-content" )
-            ]
-            [ dialogHeader renderConfig config.discardMsg config.label
-            , sortingView renderConfig config sorter
-            , Element.column
-                [ Element.width (fill |> minimum 160)
-                , Element.spacing 12
-                ]
-                [ content
-                , filterEditingButton renderConfig applyMsg clearMsg applied current
-                    |> internalPaddingBox
-                ]
-            ]
-
-
-sortingView : RenderConfig -> Config msg -> Sorters.ColumnStatus -> Element msg
-sortingView renderConfig config sorter =
-    case sorter of
-        Just _ ->
-            Element.column [ Element.width fill ]
-                [ sortAs renderConfig config SortIncreasing sorter
-                , sortAs renderConfig config SortDecreasing sorter
-                ]
-
-        Nothing ->
-            -- Unsortable
-            Element.none
-
-
-sortAs : RenderConfig -> Config msg -> SortingDirection -> Sorters.ColumnStatus -> Element msg
-sortAs renderConfig { fromSortersMsg, index } direction current =
-    let
-        terms =
-            localeTerms renderConfig
-
-        ( content, icon ) =
-            case direction of
-                SortIncreasing ->
-                    ( terms.tables.sorting.increase, Icon.sortIncreasing )
-
-                SortDecreasing ->
-                    ( terms.tables.sorting.decrease, Icon.sortDecreasing )
-
-        selected =
-            current == Just (Just direction)
-
-        msg =
-            if selected then
-                Sorters.ClearSorting
-
-            else
-                Sorters.SetSorting index direction
-    in
-    Element.row
-        (Events.onClick (fromSortersMsg msg)
-            :: Element.pointer
-            :: Element.width fill
-            :: Element.paddingEach { top = 4, left = 12, bottom = 4, right = 8 }
-            :: Border.color Colors.gray300
-            :: Border.widthEach { zeroPadding | bottom = 1 }
-            :: Element.mouseOver [ Background.color Colors.gray200 ]
-            :: ARIA.toElementAttributes ARIA.roleButton
-            |> prependIf selected (Background.color <| Colors.navyBlue200)
-        )
-        [ Text.caption content
-            |> Text.withColor (Palette.color tonePrimary brightnessMiddle)
-            |> Text.renderElement renderConfig
-        , icon content
-            |> Icon.withColor (Palette.color tonePrimary brightnessMiddle)
-            |> Icon.withSize Size.extraSmall
-            |> Icon.renderElement renderConfig
-        ]
-
-
-
 -- Specifics
 
 
@@ -357,7 +189,7 @@ singleTextFilterRender :
     -> msg
     -> Config msg
     -> Filter.Editable String
-    -> Element msg
+    -> List (Element msg)
 singleTextFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } editable =
     let
         editMsg str =
@@ -370,7 +202,7 @@ singleTextFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } ed
         |> TextField.withWidth TextField.widthFull
         |> TextField.withOnEnterPressed applyMsg
         |> TextField.renderElement renderConfig
-        |> internalPaddingBox
+        |> List.singleton
 
 
 multiTextFilterRender :
@@ -378,7 +210,7 @@ multiTextFilterRender :
     -> msg
     -> Config msg
     -> Filter.Editable (Array String)
-    -> Element msg
+    -> List (Element msg)
 multiTextFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } editableArr =
     let
         editMsg subIndex str =
@@ -397,16 +229,16 @@ multiTextFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } edi
         |> Array.push ""
         |> Array.indexedMap rowField
         |> Array.toList
-        |> Element.column [ Element.width fill, Element.spacing 8, internalPadding ]
 
 
 selectFilterRender :
-    RenderConfig
+    List String
+    -> RenderConfig
+    -> msg
     -> Config msg
-    -> List String
     -> Filter.Editable Int
-    -> Element msg
-selectFilterRender renderConfig { fromFiltersMsg, index } list { current, applied } =
+    -> List (Element msg)
+selectFilterRender list renderConfig _ { fromFiltersMsg, index } { current, applied } =
     Radio.group
         { label = renderConfig |> localeTerms >> .filters >> .select >> .description
         , onSelectMsg = \_ subIndex -> fromFiltersMsg <| Filters.EditSelect { column = index, value = subIndex }
@@ -415,7 +247,9 @@ selectFilterRender renderConfig { fromFiltersMsg, index } list { current, applie
         |> Radio.withSelected (maybeNotThen applied current)
         |> Radio.withButtons (List.indexedMap Radio.button list)
         |> Radio.withWidth Radio.widthFull
+        |> Radio.withSize Radio.sizeSM
         |> Radio.renderElement renderConfig
+        |> List.singleton
 
 
 singleDateFilterRender :
@@ -423,7 +257,7 @@ singleDateFilterRender :
     -> msg
     -> Config msg
     -> Filter.Editable DateInput
-    -> Element msg
+    -> List (Element msg)
 singleDateFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } editable =
     let
         editMsg str =
@@ -436,7 +270,7 @@ singleDateFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } ed
         |> Filter.editableWithDefault (DateInvalid "")
         |> dateInput renderConfig applyMsg editMsg datePlaceholder label
         |> TextField.renderElement renderConfig
-        |> internalPaddingBox
+        |> List.singleton
 
 
 rangeDateFilterRender :
@@ -444,7 +278,7 @@ rangeDateFilterRender :
     -> msg
     -> Config msg
     -> Filter.Editable RangeDate
-    -> Element msg
+    -> List (Element msg)
 rangeDateFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } editable =
     let
         editFromMsg str =
@@ -467,18 +301,13 @@ rangeDateFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } edi
         toPlaceholder =
             filtersTerms.range.to { date = filtersTerms.dateFormat }
     in
-    Element.column
-        [ Element.width fill
-        , Element.spacing 8
-        , internalPadding
-        ]
-        [ current.from
-            |> dateInput renderConfig applyMsg editFromMsg fromPlaceholder label
-            |> TextField.renderElement renderConfig
-        , current.to
-            |> dateInput renderConfig applyMsg editToMsg toPlaceholder label
-            |> TextField.renderElement renderConfig
-        ]
+    [ current.from
+        |> dateInput renderConfig applyMsg editFromMsg fromPlaceholder label
+        |> TextField.renderElement renderConfig
+    , current.to
+        |> dateInput renderConfig applyMsg editToMsg toPlaceholder label
+        |> TextField.renderElement renderConfig
+    ]
 
 
 periodDateFilterRender :
@@ -486,7 +315,7 @@ periodDateFilterRender :
     -> msg
     -> Config msg
     -> Filter.Editable PeriodDate
-    -> Element msg
+    -> List (Element msg)
 periodDateFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } editable =
     let
         editDateMsg str =
@@ -508,23 +337,20 @@ periodDateFilterRender renderConfig applyMsg { fromFiltersMsg, index, label } ed
             , Radio.button After filtersTerms.period.after
             ]
     in
-    Element.column
-        [ Element.width fill
-        ]
-        [ current.date
-            |> dateInput renderConfig applyMsg editDateMsg filtersTerms.dateFormat label
-            |> TextField.renderElement renderConfig
-            |> internalPaddingBox
-        , Radio.group
-            { label = filtersTerms.period.description
-            , onSelectMsg = editComparisonMsg
-            , idPrefix = "table-date-period-filter"
-            }
-            |> Radio.withSelected (Just current.comparison)
-            |> Radio.withButtons options
-            |> Radio.withWidth Radio.widthFull
-            |> Radio.renderElement renderConfig
-        ]
+    [ current.date
+        |> dateInput renderConfig applyMsg editDateMsg filtersTerms.dateFormat label
+        |> TextField.renderElement renderConfig
+    , Radio.group
+        { label = filtersTerms.period.description
+        , onSelectMsg = editComparisonMsg
+        , idPrefix = "table-date-period-filter"
+        }
+        |> Radio.withSelected (Just current.comparison)
+        |> Radio.withButtons options
+        |> Radio.withWidth Radio.widthFull
+        |> Radio.withSize Radio.sizeSM
+        |> Radio.renderElement renderConfig
+    ]
 
 
 
@@ -539,13 +365,3 @@ dateInput cfg applyMsg editMsg placeholder label current =
         |> TextField.withSize contextSize
         |> TextField.withWidth TextField.widthFull
         |> TextField.withOnEnterPressed applyMsg
-
-
-internalPadding : Attribute msg
-internalPadding =
-    Element.paddingXY 12 8
-
-
-internalPaddingBox : Element msg -> Element msg
-internalPaddingBox child =
-    Element.el [ internalPadding ] child

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -58,6 +58,35 @@ header renderConfig filter sorting config =
             terms =
                 RenderConfig.localeTerms renderConfig
 
+            applyButton =
+                terms.filters.apply
+                    |> Button.fromLabel
+                    |> Button.cmd applyMsg Button.primary
+
+            disabledApplyButton =
+                terms.filters.apply
+                    |> Button.fromLabel
+                    |> Button.disabled
+
+            clearButton =
+                terms.filters.clear
+                    |> Button.fromLabel
+                    |> Button.cmd clearMsg Button.danger
+
+            buttons =
+                case ( Filter.isApplied filter, Filter.isEdited filter ) of
+                    ( False, False ) ->
+                        [ disabledApplyButton ]
+
+                    ( False, True ) ->
+                        [ applyButton ]
+
+                    ( True, False ) ->
+                        [ clearButton ]
+
+                    ( True, True ) ->
+                        [ applyButton, clearButton ]
+
             filterRender renderer editable =
                 FilterV2.body
                     config.label
@@ -78,14 +107,7 @@ header renderConfig filter sorting config =
                         , clearSortMsg = config.fromSortersMsg Sorters.ClearSorting
                         , applied = Maybe.andThen Tuple.first sorting
                         }
-                    |> FilterV2.bodyWithButtons
-                        [ terms.filters.apply
-                            |> Button.fromLabel
-                            |> Button.cmd applyMsg Button.primary
-                        , terms.filters.clear
-                            |> Button.fromLabel
-                            |> Button.cmd clearMsg Button.danger
-                        ]
+                    |> FilterV2.bodyWithButtons buttons
                     |> FilterV2.bodyWithWidth (fill |> minimum 180)
                     |> FilterV2.bodyToElement renderConfig
         in

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -84,7 +84,7 @@ header renderConfig filter sorting config =
                             |> Button.cmd applyMsg Button.primary
                         , terms.filters.clear
                             |> Button.fromLabel
-                            |> Button.cmd applyMsg Button.danger
+                            |> Button.cmd clearMsg Button.danger
                         ]
                     |> FilterV2.bodyWithWidth (fill |> minimum 180)
                     |> FilterV2.bodyToElement renderConfig

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -9,7 +9,7 @@ import Element.Border as Border
 import Element.Events as Events
 import Element.Font as Font
 import UI.Button as Button
-import UI.Icon as Icon exposing (Icon)
+import UI.Icon as Icon
 import UI.Internal.Basics exposing (maybeNotThen, prependIf)
 import UI.Internal.Colors as Colors
 import UI.Internal.DateInput as DateInput exposing (DateInput(..), PeriodComparison(..), PeriodDate, RangeDate)
@@ -21,9 +21,8 @@ import UI.Internal.RenderConfig exposing (localeTerms)
 import UI.Internal.Size as Size exposing (Size)
 import UI.Internal.Tables.Filters as Filters
 import UI.Internal.Tables.Sorters as Sorters
-import UI.Internal.Text as Text
-import UI.Internal.Utils.Element exposing (overlay, shrinkButClip, tuplesToStyles, zIndex)
-import UI.Palette as Palette exposing (brightnessDarkest, brightnessMiddle, tonePrimary)
+import UI.Internal.Utils.Element exposing (overlay, tuplesToStyles, zIndex)
+import UI.Palette as Palette exposing (brightnessMiddle, tonePrimary)
 import UI.Radio as Radio
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Size as Size
@@ -122,66 +121,6 @@ headerSelectToggle renderConfig toggleMsg =
 -- Mostly ripped from Button with Size.Small and WidthFull
 
 
-headerNormal : RenderConfig -> msg -> String -> Sorters.ColumnStatus -> Element msg
-headerNormal renderConfig openMsg label sorting =
-    -- Button.light
-    Icon.filter label
-        |> Icon.withSize contextSize
-        |> Icon.withColor (headerColor False)
-        |> Icon.renderElement renderConfig
-        |> Element.el [ Element.alignRight ]
-        |> headerBox renderConfig openMsg label sorting False
-
-
-headerApplied : RenderConfig -> msg -> msg -> String -> String -> Sorters.ColumnStatus -> Element msg
-headerApplied renderConfig openMsg clearMsg clearHint label sorting =
-    -- Button.primary
-    Button.fromIcon (Icon.close clearHint)
-        |> Button.cmd clearMsg Button.primary
-        |> Button.withSize contextSize
-        |> Button.renderElement renderConfig
-        |> Element.el [ Element.alignRight ]
-        |> headerBox renderConfig openMsg label sorting True
-
-
-headerText : RenderConfig -> Bool -> String -> Element msg
-headerText renderConfig isApplied label =
-    label
-        |> Text.ellipsizedText renderConfig Text.SizeCaption
-        |> Element.el
-            [ Font.size textSize
-            , Font.semiBold
-            , Font.color (Palette.toElementColor <| headerColor isApplied)
-            , Element.centerY
-            ]
-
-
-headerBox : RenderConfig -> msg -> String -> Sorters.ColumnStatus -> Bool -> Element msg -> Element msg
-headerBox renderConfig openMsg label sorting isFilterApplied rightIcon =
-    Element.row (Element.onIndividualClick openMsg :: headerAttrs isFilterApplied)
-        [ Element.row shrinkButClip
-            [ headerText renderConfig isFilterApplied label
-            , headerSorting renderConfig isFilterApplied sorting
-            ]
-            |> Element.el [ Element.width fill, Element.clip ]
-        , rightIcon
-        ]
-
-
-headerColor : Bool -> Palette.Color
-headerColor isApplied =
-    if isApplied then
-        Palette.color
-            tonePrimary
-            brightnessMiddle
-            |> Palette.setContrasting True
-
-    else
-        Palette.color
-            tonePrimary
-            brightnessDarkest
-
-
 headerPadX : Int
 headerPadX =
     (36 - 16) // 2
@@ -221,20 +160,6 @@ headerAttrs isApplied =
         :: (ARIA.toElementAttributes ARIA.roleButton
                 ++ workingTheme
            )
-
-
-headerSorting : RenderConfig -> Bool -> Sorters.ColumnStatus -> Element msg
-headerSorting renderConfig isFilterApplied status =
-    case Maybe.andThen identity status of
-        Just direction ->
-            sortingDirectionToIcon renderConfig direction
-                |> Icon.withCustomSize 12
-                |> Icon.withColor (headerColor isFilterApplied)
-                |> Icon.renderElement renderConfig
-                |> Element.el [ Element.centerY ]
-
-        Nothing ->
-            Element.none
 
 
 
@@ -624,13 +549,3 @@ internalPadding =
 internalPaddingBox : Element msg -> Element msg
 internalPaddingBox child =
     Element.el [ internalPadding ] child
-
-
-sortingDirectionToIcon : RenderConfig -> SortingDirection -> Icon
-sortingDirectionToIcon _ direction =
-    case direction of
-        SortIncreasing ->
-            Icon.sortIncreasing ""
-
-        SortDecreasing ->
-            Icon.sortDecreasing ""

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -64,8 +64,8 @@ header renderConfig filter sorting config =
                     |> FilterV2.bodyWithSorting
                         { smaller = "A"
                         , larger = "Z"
-                        , ascendingSortMsg = sortMsg SortIncreasing
-                        , descendingSortMsg = sortMsg SortDecreasing
+                        , ascendingSortMsg = sortMsg SortAscending
+                        , descendingSortMsg = sortMsg SortDescending
                         , clearSortMsg = config.fromSortersMsg Sorters.ClearSorting
                         , applied = Maybe.andThen identity sorting
                         }

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -3,7 +3,7 @@ module UI.Internal.Tables.FiltersView exposing (Config, header, headerSelectTogg
 -- WARNING: Don't use any other Size.* beyond "contextSize"
 
 import Array exposing (Array)
-import Element exposing (Attribute, Element, fill, minimum, px)
+import Element exposing (Element, fill, minimum, px)
 import Element.Background as Background
 import UI.Button as Button
 import UI.Icon as Icon

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -14,11 +14,12 @@ import UI.Internal.Basics exposing (maybeNotThen, prependIf)
 import UI.Internal.Colors as Colors
 import UI.Internal.DateInput as DateInput exposing (DateInput(..), PeriodComparison(..), PeriodDate, RangeDate)
 import UI.Internal.Filter.Model as Filter exposing (Filter)
+import UI.Internal.Filter.Sorter exposing (SortingDirection(..))
 import UI.Internal.Primitives as Primitives
 import UI.Internal.RenderConfig exposing (localeTerms)
 import UI.Internal.Size as Size exposing (Size)
 import UI.Internal.Tables.Filters as Filters
-import UI.Internal.Tables.Sorters as Sorters exposing (SortingDirection(..))
+import UI.Internal.Tables.Sorters as Sorters
 import UI.Internal.Text as Text
 import UI.Internal.Utils.Element exposing (overlay, shrinkButClip, tuplesToStyles, zIndex)
 import UI.Palette as Palette exposing (brightnessDarkest, brightnessMiddle, tonePrimary)

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -15,6 +15,7 @@ import UI.Internal.Colors as Colors
 import UI.Internal.DateInput as DateInput exposing (DateInput(..), PeriodComparison(..), PeriodDate, RangeDate)
 import UI.Internal.Filter.Model as Filter exposing (Filter)
 import UI.Internal.Filter.Sorter exposing (SortingDirection(..))
+import UI.Internal.Filter.View as FilterV2
 import UI.Internal.Primitives as Primitives
 import UI.Internal.RenderConfig exposing (localeTerms)
 import UI.Internal.Size as Size exposing (Size)
@@ -82,19 +83,21 @@ header renderConfig filter sorting config =
                 selectFilterRender renderConfig config list editable
                     |> dialog renderConfig config filter sorting clearMsg applyMsg
 
-    else if Filter.isApplied filter then
-        headerApplied renderConfig
-            config.openMsg
-            clearMsg
-            (renderConfig |> localeTerms >> .filters >> .clear)
-            config.label
-            sorting
-
     else
-        headerNormal renderConfig
-            config.openMsg
+        FilterV2.header
             config.label
-            sorting
+            config.openMsg
+            |> FilterV2.headerWithSize FilterV2.extraSmall
+            |> FilterV2.headerWithSorting
+                (Maybe.andThen identity sorting)
+            |> FilterV2.headerWithApplied
+                (if Filter.isApplied filter then
+                    Just { preview = "1", discardMsg = clearMsg }
+
+                 else
+                    Nothing
+                )
+            |> FilterV2.headerToElement renderConfig
 
 
 

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -5,8 +5,8 @@ module UI.Internal.Tables.Sorters exposing
     , get
     , itemsApplySorting
     , sortAscending
-    , sortBy
     , sortDescending
+    , sortWith
     , sortersEmpty
     , unsortable
     , update
@@ -14,7 +14,7 @@ module UI.Internal.Tables.Sorters exposing
 
 import UI.Effect as Effect exposing (Effect)
 import UI.Internal.Analytics as Analytics
-import UI.Internal.Filter.Sorter as Sorter exposing (Sorter(..), SortingDirection(..))
+import UI.Internal.Filter.Sorter as Sorter exposing (Sorter, SortingDirection(..))
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Utils.TypeNumbers as T
 
@@ -93,13 +93,13 @@ sortersEmpty =
         }
 
 
-sortBy :
-    (item -> String)
+sortWith :
+    Sorter item
     -> Sorters item columns
     -> Sorters item (T.Increase columns)
-sortBy fn (Sorters accu) =
+sortWith customSorter (Sorters accu) =
     Sorters
-        { columns = NArray.push (Just <| AlphabeticalSortable fn) accu.columns
+        { columns = NArray.push (Just customSorter) accu.columns
         , status = accu.status
         }
 

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -4,9 +4,9 @@ module UI.Internal.Tables.Sorters exposing
     , Sorters
     , get
     , itemsApplySorting
+    , sortAscending
     , sortBy
-    , sortDecreasing
-    , sortIncreasing
+    , sortDescending
     , sortersEmpty
     , unsortable
     , update
@@ -45,7 +45,7 @@ update msg sorters =
         SetSorting index direction ->
             let
                 reverse =
-                    direction == SortDecreasing
+                    direction == SortDescending
             in
             ( sort direction index sorters
             , Analytics.SetSorting index reverse
@@ -78,10 +78,10 @@ itemsApplySorting (Sorters sorters) items =
                     Sorter.sort status.by items
             in
             case status.direction of
-                SortIncreasing ->
+                SortAscending ->
                     sortedItems
 
-                SortDecreasing ->
+                SortDescending ->
                     List.reverse sortedItems
 
 
@@ -112,14 +112,14 @@ unsortable (Sorters accu) =
         }
 
 
-sortIncreasing : Int -> Sorters item columns -> Sorters item columns
-sortIncreasing =
-    sort SortIncreasing
+sortAscending : Int -> Sorters item columns -> Sorters item columns
+sortAscending =
+    sort SortAscending
 
 
-sortDecreasing : Int -> Sorters item columns -> Sorters item columns
-sortDecreasing =
-    sort SortDecreasing
+sortDescending : Int -> Sorters item columns -> Sorters item columns
+sortDescending =
+    sort SortDescending
 
 
 sort : SortingDirection -> Int -> Sorters item columns -> Sorters item columns

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -35,8 +35,8 @@ type Sorters item columns
         }
 
 
-type alias ColumnStatus =
-    Maybe (Maybe SortingDirection)
+type alias ColumnStatus item =
+    Maybe ( Maybe SortingDirection, Sorter item )
 
 
 update : Msg -> Sorters item columns -> ( Sorters item columns, Effect msg )
@@ -140,7 +140,7 @@ sort direction column ((Sorters accu) as sorters) =
             sorters
 
 
-get : Int -> Sorters item columns -> ColumnStatus
+get : Int -> Sorters item columns -> ColumnStatus item
 get index (Sorters { columns, status }) =
     let
         getDirection currentSorting =
@@ -152,8 +152,8 @@ get index (Sorters { columns, status }) =
 
         isSortableThen sortable =
             case sortable of
-                Just _ ->
-                    Just (Maybe.andThen getDirection status)
+                Just by ->
+                    Just ( Maybe.andThen getDirection status, by )
 
                 Nothing ->
                     Nothing

--- a/src/UI/Internal/Tables/Sorters.elm
+++ b/src/UI/Internal/Tables/Sorters.elm
@@ -99,16 +99,7 @@ sortBy :
     -> Sorters item (T.Increase columns)
 sortBy fn (Sorters accu) =
     Sorters
-        { columns =
-            NArray.push
-                ({ retrieve = fn
-                 , smallerFirst = True
-                 , emptyOnTail = True
-                 }
-                    |> AlphanumericSortable
-                    |> Just
-                )
-                accu.columns
+        { columns = NArray.push (Just <| AlphabeticalSortable fn) accu.columns
         , status = accu.status
         }
 

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -1,6 +1,6 @@
 module UI.Internal.Utils.Element exposing
-    ( clickElsewhereToLeave
-    , css
+    ( css
+    , customOverlay
     , id
     , overflowAttrs
     , overflowVisible
@@ -59,8 +59,8 @@ id value =
         |> Element.htmlAttribute
 
 
-clickElsewhereToLeave : msg -> List (Attribute msg) -> Element msg -> Element msg
-clickElsewhereToLeave onClickMsg backgroundStyleAttributes foregroundContent =
+customOverlay : msg -> List (Attribute msg) -> Element msg -> Element msg
+customOverlay onClickMsg backgroundStyleAttributes foregroundContent =
     let
         backgroundAttributes =
             positionFixed
@@ -83,7 +83,7 @@ clickElsewhereToLeave onClickMsg backgroundStyleAttributes foregroundContent =
 
 overlay : msg -> Element msg -> Element msg
 overlay closeMsg content =
-    clickElsewhereToLeave closeMsg [ Colors.overlayBackground ] content
+    customOverlay closeMsg [ Colors.overlayBackground ] content
 
 
 shrinkButClip : List (Attribute msg)

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -62,15 +62,22 @@ clickElsewhereToLeave : msg -> List (Attribute msg) -> Element msg -> Element ms
 clickElsewhereToLeave onClickMsg backgroundStyleAttributes foregroundContent =
     let
         backgroundAttributes =
-            [ positionFixed -- Needs for starting at the top-left corner
-            , zIndex 8
-            , Element.htmlAttribute <| HtmlAttrs.style "top" "0"
-            , Element.htmlAttribute <| HtmlAttrs.style "left" "0"
-            , Element.htmlAttribute <| HtmlAttrs.style "width" "100vw"
-            , Element.htmlAttribute <| HtmlAttrs.style "height" "100vh"
-            , Events.onClick onClickMsg
-            ]
-                ++ backgroundStyleAttributes
+            positionFixed
+                :: zIndex 8
+                :: Element.htmlAttribute
+            <|
+                HtmlAttrs.style "top" "0"
+                    :: Element.htmlAttribute
+                <|
+                    HtmlAttrs.style "left" "0"
+                        :: Element.htmlAttribute
+                    <|
+                        HtmlAttrs.style "width" "100vw"
+                            :: Element.htmlAttribute
+                        <|
+                            HtmlAttrs.style "height" "100vh"
+                                :: Events.onClick onClickMsg
+                                :: backgroundStyleAttributes
     in
     Element.el
         [ Element.width fill

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -5,6 +5,7 @@ module UI.Internal.Utils.Element exposing
     , overflowAttrs
     , overflowVisible
     , overlay
+    , overlayZIndex
     , shrinkButClip
     , style
     , tabIndex
@@ -64,7 +65,7 @@ clickElsewhereToLeave onClickMsg backgroundStyleAttributes foregroundContent =
         backgroundAttributes =
             positionFixed
                 -- Needs for starting at the top-left corner
-                :: zIndex 8
+                :: zIndex overlayZIndex
                 :: (Element.htmlAttribute <| HtmlAttrs.style "top" "0")
                 :: (Element.htmlAttribute <| HtmlAttrs.style "left" "0")
                 :: (Element.htmlAttribute <| HtmlAttrs.style "width" "100vw")
@@ -92,6 +93,11 @@ shrinkButClip =
         , ( "max-width", "100%" )
         , ( "overflow", "clip" )
         ]
+
+
+overlayZIndex : Int
+overlayZIndex =
+    8
 
 
 

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -1,11 +1,13 @@
 module UI.Internal.Utils.Element exposing
-    ( css
+    ( clickElsewhereToLeave
+    , css
     , id
     , overflowAttrs
     , overflowVisible
     , overlay
     , shrinkButClip
     , style
+    , tabIndex
     , title
     , tuplesToStyles
     , zIndex
@@ -56,29 +58,31 @@ id value =
         |> Element.htmlAttribute
 
 
-overlayBackground : msg -> Element msg
-overlayBackground onClickMsg =
+clickElsewhereToLeave : msg -> List (Attribute msg) -> Element msg -> Element msg
+clickElsewhereToLeave onClickMsg backgroundStyleAttributes foregroundContent =
+    let
+        backgroundAttributes =
+            [ positionFixed -- Needs for starting at the top-left corner
+            , zIndex 8
+            , Element.htmlAttribute <| HtmlAttrs.style "top" "0"
+            , Element.htmlAttribute <| HtmlAttrs.style "left" "0"
+            , Element.htmlAttribute <| HtmlAttrs.style "width" "100vw"
+            , Element.htmlAttribute <| HtmlAttrs.style "height" "100vh"
+            , Events.onClick onClickMsg
+            ]
+                ++ backgroundStyleAttributes
+    in
     Element.el
-        [ positionFixed -- Needs for starting at the top-left corner
-        , zIndex 8
-        , Colors.overlayBackground
-        , Element.htmlAttribute <| HtmlAttrs.style "top" "0"
-        , Element.htmlAttribute <| HtmlAttrs.style "left" "0"
-        , Element.htmlAttribute <| HtmlAttrs.style "width" "100vw"
-        , Element.htmlAttribute <| HtmlAttrs.style "height" "100vh"
-        , Events.onClick onClickMsg
+        [ Element.width fill
+        , Element.height (shrink |> minimum 1)
+        , Element.inFront foregroundContent
         ]
-        Element.none
+        (Element.el backgroundAttributes Element.none)
 
 
 overlay : msg -> Element msg -> Element msg
 overlay closeMsg content =
-    Element.el
-        [ Element.width fill
-        , Element.height (shrink |> minimum 1)
-        , Element.inFront content
-        ]
-        (overlayBackground closeMsg)
+    clickElsewhereToLeave closeMsg [ Colors.overlayBackground ] content
 
 
 shrinkButClip : List (Attribute msg)
@@ -107,3 +111,10 @@ overflowVisible =
 zIndex : Int -> Attribute msg
 zIndex val =
     Element.htmlAttribute <| HtmlAttrs.style "z-index" (String.fromInt val)
+
+
+{-| Give preference to UI.Util.Focus
+-}
+tabIndex : Int -> Attribute msg
+tabIndex val =
+    Element.htmlAttribute <| HtmlAttrs.style "tabIndex" (String.fromInt val)

--- a/src/UI/Internal/Utils/Element.elm
+++ b/src/UI/Internal/Utils/Element.elm
@@ -63,21 +63,14 @@ clickElsewhereToLeave onClickMsg backgroundStyleAttributes foregroundContent =
     let
         backgroundAttributes =
             positionFixed
+                -- Needs for starting at the top-left corner
                 :: zIndex 8
-                :: Element.htmlAttribute
-            <|
-                HtmlAttrs.style "top" "0"
-                    :: Element.htmlAttribute
-                <|
-                    HtmlAttrs.style "left" "0"
-                        :: Element.htmlAttribute
-                    <|
-                        HtmlAttrs.style "width" "100vw"
-                            :: Element.htmlAttribute
-                        <|
-                            HtmlAttrs.style "height" "100vh"
-                                :: Events.onClick onClickMsg
-                                :: backgroundStyleAttributes
+                :: (Element.htmlAttribute <| HtmlAttrs.style "top" "0")
+                :: (Element.htmlAttribute <| HtmlAttrs.style "left" "0")
+                :: (Element.htmlAttribute <| HtmlAttrs.style "width" "100vw")
+                :: (Element.htmlAttribute <| HtmlAttrs.style "height" "100vh")
+                :: Events.onClick onClickMsg
+                :: backgroundStyleAttributes
     in
     Element.el
         [ Element.width fill

--- a/src/UI/Radio.elm
+++ b/src/UI/Radio.elm
@@ -356,11 +356,19 @@ renderButton renderConfig (RadioSize size) id (RadioButton _ label) state =
             )
                 :: Utils.id id
                 :: SelectionControl.buttonAttributes size
+
+        text =
+            case size of
+                SizeMD ->
+                    Text.subtitle1
+
+                SizeSM ->
+                    Text.body2
     in
     Element.row
         buttonAttributes
         [ Element.el radioAttrs radioBulletContent
-        , Text.body1 label |> Text.renderElement renderConfig
+        , text label |> Text.renderElement renderConfig
         ]
 
 

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -411,16 +411,22 @@ updateMobileToggle state index =
 
 updateFilters : StateModel msg item columns -> Filters.Msg -> ( State msg item columns, Effect msg )
 updateFilters state subMsg =
+    let
+        map ( newFilters, { effects, closeDialog } ) =
+            ( applyFilters newFilters <|
+                if closeDialog then
+                    { state | filterDialog = Nothing }
+
+                else
+                    state
+            , effects
+            )
+    in
     case state.filters of
         Just filters ->
             filters
                 |> Filters.update subMsg
-                |> (\( newFilters, subCmd ) ->
-                        ( state
-                            |> applyFilters newFilters
-                        , subCmd
-                        )
-                   )
+                |> map
 
         Nothing ->
             ( State state, Effect.none )

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -1114,7 +1114,7 @@ sortBy =
 -}
 sortDecreasing : Int -> Sorters item columns -> Sorters item columns
 sortDecreasing =
-    Sorters.sortDecreasing
+    Sorters.sortDescending
 
 
 {-| Changes the initial sorting to some columns as increasing.
@@ -1127,7 +1127,7 @@ sortDecreasing =
 -}
 sortIncreasing : Int -> Sorters item columns -> Sorters item columns
 sortIncreasing =
-    Sorters.sortIncreasing
+    Sorters.sortAscending
 
 
 {-| An empty [`Sorters`](#Sorters) set.

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -10,7 +10,7 @@ module UI.Tables.Stateful exposing
     , periodSingle, pariodAfter, periodBefore, localPeriodDateFilter, remotePeriodDateFilter
     , localSelectFilter, remoteSelectFilter
     , Sorters, stateWithSorters
-    , sortersEmpty, sortBy, unsortable
+    , sortersEmpty, sortBy, sortByFloat, sortByInteger, sortByChar, sortWith, unsortable
     , sortDecreasing, sortIncreasing
     , withWidth
     , stateWithSelection, stateIsSelected
@@ -140,7 +140,7 @@ And on model:
 # Sorting
 
 @docs Sorters, stateWithSorters
-@docs sortersEmpty, sortBy, unsortable
+@docs sortersEmpty, sortBy, sortByFloat, sortByInteger, sortByChar, sortWith, unsortable
 @docs sortDecreasing, sortIncreasing
 
 
@@ -177,6 +177,7 @@ import UI.Effect as Effect exposing (Effect)
 import UI.Internal.Basics exposing (ifThenElse, maybeThen, prependMaybe)
 import UI.Internal.DateInput as DateInput exposing (DateInput, PeriodDate, RangeDate)
 import UI.Internal.Filter.Model as Filter
+import UI.Internal.Filter.Sorter exposing (Sorter(..))
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Internal.RenderConfig exposing (localeTerms)
 import UI.Internal.Tables.Common exposing (..)
@@ -1087,7 +1088,7 @@ stateWithSorters sorters (State state) =
         }
 
 
-{-| Describes how to convert a column's value to a sortable `List String`.
+{-| Allow sorting a column alphabetically.
 
     sortersInit =
         sortersEmpty
@@ -1100,8 +1101,76 @@ sortBy :
     (item -> String)
     -> Sorters item columns
     -> Sorters item (T.Increase columns)
-sortBy =
-    Sorters.sortBy
+sortBy fn =
+    Sorters.sortWith (AlphabeticalSortable fn)
+
+
+{-| Allow sorting a column using a Float value.
+
+    sortersInit =
+        sortersEmpty
+            |> unsortable
+            |> sortByFloat .value
+            |> sortByFloat .timestamp
+            |> sortByFloat .average
+
+-}
+sortByFloat :
+    (item -> Float)
+    -> Sorters item columns
+    -> Sorters item (T.Increase columns)
+sortByFloat fn =
+    Sorters.sortWith (FloatSortable fn)
+
+
+{-| Allow sorting a column using an Integer value.
+
+    sortersInit =
+        sortersEmpty
+            |> unsortable
+            |> sortByInteger .count
+            |> sortByInteger .areaCode
+            |> sortByInteger .hour
+
+-}
+sortByInteger :
+    (item -> Int)
+    -> Sorters item columns
+    -> Sorters item (T.Increase columns)
+sortByInteger fn =
+    Sorters.sortWith (IntegerSortable fn)
+
+
+{-| Allow sorting a column using a Char value.
+
+    sortersInit =
+        sortersEmpty
+            |> unsortable
+            |> sortByChar .firstLetter
+
+-}
+sortByChar :
+    (item -> Char)
+    -> Sorters item columns
+    -> Sorters item (T.Increase columns)
+sortByChar fn =
+    Sorters.sortWith (CharSortable fn)
+
+
+{-| Allow sorting a column with a custom function.
+
+    sortersInit =
+        sortersEmpty
+            |> unsortable
+            |> sortWith (List.sortWith flippedComparison)
+
+-}
+sortWith :
+    (List item -> List item)
+    -> Sorters item columns
+    -> Sorters item (T.Increase columns)
+sortWith fn =
+    Sorters.sortWith (CustomSortable fn)
 
 
 {-| Changes the initial sorting to some columns as descreasing.

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -10,7 +10,7 @@ module UI.Tables.Stateful exposing
     , periodSingle, pariodAfter, periodBefore, localPeriodDateFilter, remotePeriodDateFilter
     , localSelectFilter, remoteSelectFilter
     , Sorters, stateWithSorters
-    , sortersEmpty, sortBy, sortByFloat, sortByInteger, sortByChar, sortWith, unsortable
+    , sortersEmpty, sortBy, sortByFloat, sortByInt, sortByChar, sortWith, unsortable
     , sortDecreasing, sortIncreasing
     , withWidth
     , stateWithSelection, stateIsSelected
@@ -140,7 +140,7 @@ And on model:
 # Sorting
 
 @docs Sorters, stateWithSorters
-@docs sortersEmpty, sortBy, sortByFloat, sortByInteger, sortByChar, sortWith, unsortable
+@docs sortersEmpty, sortBy, sortByFloat, sortByInt, sortByChar, sortWith, unsortable
 @docs sortDecreasing, sortIncreasing
 
 
@@ -1128,16 +1128,16 @@ sortByFloat fn =
     sortersInit =
         sortersEmpty
             |> unsortable
-            |> sortByInteger .count
-            |> sortByInteger .areaCode
-            |> sortByInteger .hour
+            |> sortByInt .count
+            |> sortByInt .areaCode
+            |> sortByInt .hour
 
 -}
-sortByInteger :
+sortByInt :
     (item -> Int)
     -> Sorters item columns
     -> Sorters item (T.Increase columns)
-sortByInteger fn =
+sortByInt fn =
     Sorters.sortWith (IntegerSortable fn)
 
 
@@ -1427,7 +1427,7 @@ filterHeader :
     -> Maybe Int
     -> Column
     -> Filter.Filter msg item
-    -> Sorters.ColumnStatus
+    -> Sorters.ColumnStatus item
     -> Int
     -> Element msg
 filterHeader renderConfig toExternalMsg selected (Column header { width }) filter sorter index =

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -176,6 +176,7 @@ import UI.Checkbox as Checkbox exposing (checkbox)
 import UI.Effect as Effect exposing (Effect)
 import UI.Internal.Basics exposing (ifThenElse, maybeThen, prependMaybe)
 import UI.Internal.DateInput as DateInput exposing (DateInput, PeriodDate, RangeDate)
+import UI.Internal.Filter.Model as Filter
 import UI.Internal.NArray as NArray exposing (NArray)
 import UI.Internal.RenderConfig exposing (localeTerms)
 import UI.Internal.Tables.Common exposing (..)
@@ -743,8 +744,10 @@ localSingleTextFilter :
     -> (item -> String)
     -> Filters msg item columns
     -> Filters msg item (T.Increase columns)
-localSingleTextFilter =
-    Filters.singleTextLocal
+localSingleTextFilter initValue getData accu =
+    Filters.push
+        (Filter.singleTextLocal initValue getData)
+        accu
 
 
 {-| A filter with one single text field.
@@ -762,8 +765,10 @@ remoteSingleTextFilter :
     -> (Maybe String -> msg)
     -> Filters msg item columns
     -> Filters msg item (T.Increase columns)
-remoteSingleTextFilter =
-    Filters.singleTextRemote
+remoteSingleTextFilter initValue applyMsg accu =
+    Filters.push
+        (Filter.singleTextRemote initValue applyMsg)
+        accu
 
 
 {-| A filter with multiple text field.
@@ -787,8 +792,10 @@ localMultiTextFilter :
     -> (item -> String)
     -> Filters msg item columns
     -> Filters msg item (T.Increase columns)
-localMultiTextFilter =
-    Filters.multiTextLocal
+localMultiTextFilter initValue getData accu =
+    Filters.push
+        (Filter.multiTextLocal initValue getData)
+        accu
 
 
 {-| A filter with multiple text field.
@@ -808,8 +815,10 @@ remoteMultiTextFilter :
     -> (List String -> msg)
     -> Filters msg item columns
     -> Filters msg item (T.Increase columns)
-remoteMultiTextFilter =
-    Filters.multiTextRemote
+remoteMultiTextFilter initValue applyMsg accu =
+    Filters.push
+        (Filter.multiTextRemote initValue applyMsg)
+        accu
 
 
 {-| A filter for dates with one single field.
@@ -826,8 +835,10 @@ localSingleDateFilter :
     -> (item -> Time.Posix)
     -> Filters msg item columns
     -> Filters msg item (T.Increase columns)
-localSingleDateFilter =
-    Filters.singleDateLocal
+localSingleDateFilter timeZone initValue getData accu =
+    Filters.push
+        (Filter.singleDateLocal timeZone initValue getData)
+        accu
 
 
 {-| A filter for dates with one single field.
@@ -845,8 +856,10 @@ remoteSingleDateFilter :
     -> (Maybe DateInput -> msg)
     -> Filters.Filters msg item columns
     -> Filters.Filters msg item (T.Increase columns)
-remoteSingleDateFilter =
-    Filters.singleDateRemote
+remoteSingleDateFilter timeZone initValue applyMsg accu =
+    Filters.push
+        (Filter.singleDateRemote timeZone initValue applyMsg)
+        accu
 
 
 {-| A filter for dates in an expected range.
@@ -868,8 +881,10 @@ localRangeDateFilter :
     -> (item -> Time.Posix)
     -> Filters msg item columns
     -> Filters msg item (T.Increase columns)
-localRangeDateFilter =
-    Filters.rangeDateLocal
+localRangeDateFilter timeZone fromTime toTime getData accu =
+    Filters.push
+        (Filter.rangeDateLocal timeZone fromTime toTime getData)
+        accu
 
 
 {-| A filter for dates in an expected range.
@@ -893,8 +908,10 @@ remoteRangeDateFilter :
     -> (Maybe RangeDate -> msg)
     -> Filters msg item columns
     -> Filters msg item (T.Increase columns)
-remoteRangeDateFilter =
-    Filters.rangeDateRemote
+remoteRangeDateFilter timeZone fromTime toTime applyMsg accu =
+    Filters.push
+        (Filter.rangeDateRemote timeZone fromTime toTime applyMsg)
+        accu
 
 
 {-| A filter for a single date, dates before specified date, or dates after specified date.
@@ -916,8 +933,10 @@ localPeriodDateFilter :
     -> (item -> Time.Posix)
     -> Filters msg item columns
     -> Filters msg item (T.Increase columns)
-localPeriodDateFilter =
-    Filters.periodDateLocal
+localPeriodDateFilter timeZone initValue initComparison getData accu =
+    Filters.push
+        (Filter.periodDateLocal timeZone initValue initComparison getData)
+        accu
 
 
 {-| A filter for a single date, dates before specified date, or dates after specified date.
@@ -941,8 +960,10 @@ remotePeriodDateFilter :
     -> (Maybe PeriodDate -> msg)
     -> Filters msg item columns
     -> Filters msg item (T.Increase columns)
-remotePeriodDateFilter =
-    Filters.periodDateRemote
+remotePeriodDateFilter timeZone initValue initComparison applyMsg accu =
+    Filters.push
+        (Filter.periodDateRemote timeZone initValue initComparison applyMsg)
+        accu
 
 
 {-| A filter for custom radio buttons.
@@ -962,8 +983,10 @@ localSelectFilter :
     -> (item -> Int -> Bool)
     -> Filters msg item columns
     -> Filters msg item (T.Increase columns)
-localSelectFilter =
-    Filters.selectLocal
+localSelectFilter initList initSelection getData accu =
+    Filters.push
+        (Filter.selectLocal initList initSelection getData)
+        accu
 
 
 {-| A filter for custom radio buttons.
@@ -985,8 +1008,10 @@ remoteSelectFilter :
     -> (Maybe Int -> msg)
     -> Filters msg item columns
     -> Filters msg item (T.Increase columns)
-remoteSelectFilter =
-    Filters.selectRemote
+remoteSelectFilter initList initSelection applyMsg accu =
+    Filters.push
+        (Filter.selectRemote initList initSelection applyMsg)
+        accu
 
 
 
@@ -1332,7 +1357,7 @@ filterHeader :
     -> (Msg item -> msg)
     -> Maybe Int
     -> Column
-    -> Filters.Filter msg item
+    -> Filter.Filter msg item
     -> Sorters.ColumnStatus
     -> Int
     -> Element msg

--- a/src/UI/Text.elm
+++ b/src/UI/Text.elm
@@ -24,6 +24,8 @@ A text can be created and rendered as in the following pipeline:
         |> Text.renderElement renderConfig
         |> Element.el [ Element.width (px 200) ]
 
+**Note**: Don't forget to import "Fira Sans" family, with the weights: 400, 500, 600 and 700.
+
 
 # Building
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5480,10 +5480,10 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-paack-ui-assets@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/paack-ui-assets/-/paack-ui-assets-0.1.1.tgz#6a9f82931263644309a951add288053e733f4b2d"
-  integrity sha512-UpFjbcxN+0TG7+f6mkcp1ReIrXCySHPD8oKgQXk7CPlUSGGWgBEoaDHC5i8PSQ+BGJUMh01CSYTeczF/0Xt2uQ==
+paack-ui-assets@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/paack-ui-assets/-/paack-ui-assets-0.1.2.tgz#6dd2a705ce60ed6a7a0f72503f4ee62740fc981b"
+  integrity sha512-5jaUBC0jSpZs4ys0IyYU12OwsLJbTQ4OmWWAi/ahwHFw0dqRzK26RC4eo0u5UB/2rDNzeFw3pcHY5GUjmO+wTw==
 
 package-json@^6.3.0:
   version "6.5.0"


### PR DESCRIPTION
<div align="center"><img src="https://ae01.alicdn.com/kf/Hf8fe8174b87a4b428e14fc1451f744dea/Filtro-de-caf-em-casa-de-a-o-inoxid-vel-reus-vel-despeje-sobre-dripper-filtro.jpg_Q90.jpg_.webp" width=240 alt="joke" title="reusable filter" /></div>

#### :thinking: What?

- Bump paack-ui-assets;
- Add filter component's internals;
- Move table's filter to the component's internal;
- Update style to match Figma;
- Allow sorting with more than alphabetically;
- Add notes about "Fira Sans" weights;
- Fix radio's button text-style.

#### :man_shrugging: Why?

- First part of what I need in LMO;
- Fresh look.

#### :pushpin: Jira Issue

[DES-111](https://paacklogistics.atlassian.net/browse/DES-111) and [LMO-515](https://paacklogistics.atlassian.net/browse/LMO-515).

#### :no_good: Blocked by

Nothing.

#### :clipboard: Pending

In a future PR:
- The API to the Final reusable Filter;
- headerWithFilter / bodyWithFilter;
- Fix of the date error state;
- Fix of the "portional-width" minimal size.