### PR TITLE
Dropdown scrollbar

### DIFF
--- a/showcase/src/Dropdown/Stories.elm
+++ b/showcase/src/Dropdown/Stories.elm
@@ -82,6 +82,7 @@ basicDropdownView model =
         |> Dropdown.withItems books
         |> Dropdown.withSelected model.selectedBook
         |> Dropdown.withItemToText .title
+        |> Dropdown.withMaximumListHeight 200
 
 
 basicDropdownCode : String
@@ -96,6 +97,7 @@ Dropdown.basic
     |> Dropdown.withItems books
     |> Dropdown.withSelected model.selectedBook
     |> Dropdown.withItemToText .title
+    |> Dropdown.withMaximumListHeight 200
     |> Dropdown.renderElement renderConfig
     """
 


### PR DESCRIPTION
#### :thinking: What?

Limits the dropdown part of the Dropdown component to have at most `200px` of height and adds a scrollbar for longer dropdowns.

> also some minor documentation fixes

#### :man_shrugging: Why?

The current dropdown has no height limit, this can cause issues with or long lists and/or shorter displays.

### :fire: Extra

Change `PaackEng/elm-ui-dropdown` to send `DomFocus` effects when selection change.
