### PR TITLE
Add `Filter` support to `ListView`

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "6.5.0",
+    "version": "6.6.0",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",

--- a/src/UI/Filter.elm
+++ b/src/UI/Filter.elm
@@ -1,6 +1,6 @@
 module UI.Filter exposing
     ( Filter
-    , FilterSize, withSize, sizeMedium, sizeExtraSmall, withWidth
+    , FilterSize, withSize, sizeMedium, sizeExtraSmall, withWidth, withAlignRight
     , renderElement
     , FilterModel, fromModel
     , singleTextFilter, multiTextFilter, singleDateFilter, rangeDateFilter, periodDateFilter, radioFilter
@@ -23,7 +23,7 @@ module UI.Filter exposing
 
 ## Size
 
-@docs FilterSize, withSize, sizeMedium, sizeExtraSmall, withWidth
+@docs FilterSize, withSize, sizeMedium, sizeExtraSmall, withWidth, withAlignRight
 
 
 ## Rendering
@@ -187,6 +187,7 @@ customFilter label { openMsg, closeMsg, isOpen } =
         , rowsHeight = Nothing
         , buttons = always []
         , applied = Nothing
+        , alignRight = False
         }
 
 
@@ -230,6 +231,13 @@ withSize (FilterSize newSize) (Filter filter) =
 withWidth : Element.Length -> Filter msg -> Filter msg
 withWidth newWidth (Filter filter) =
     Filter { filter | width = newWidth }
+
+
+{-| Aligns the filter to the right.
+-}
+withAlignRight : Filter msg -> Filter msg
+withAlignRight (Filter filter) =
+    Filter { filter | alignRight = True }
 
 
 {-| Sets the content of the filter's dialog when open.
@@ -501,6 +509,7 @@ fromModel label toExternalMsg (FilterModel model) =
         , clearSortingMsg = toExternalMsg <| SetSorting Nothing
         , label = label
         , isOpen = model.isOpen
+        , alignRight = False
         }
         model.filter
         model.sorting

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -22,17 +22,12 @@ import UI.Size as Size exposing (Size)
 import UI.TextField as TextField exposing (TextField)
 import UI.Utils.ARIA as ARIA
 import UI.Utils.Element as Element exposing (RectangleSides, zeroPadding)
+import UI.Internal.Basics exposing (prependIf)
 
 
 type FilterSize
     = ExtraSmall
     | Medium
-
-
-type alias CommonOptions =
-    { width : Element.Length
-    , size : FilterSize
-    }
 
 
 type alias FullFilter msg =
@@ -47,6 +42,7 @@ type alias FullFilter msg =
     , rowsHeight : Maybe Int
     , buttons : RenderConfig -> List (Button msg)
     , applied : Maybe { preview : String, clearMsg : msg }
+    , alignRight : Bool
     }
 
 
@@ -74,9 +70,10 @@ headerToElement :
             , size : FilterSize
             , sorting : Maybe (FilterSorting msg)
             , applied : Maybe { preview : String, clearMsg : msg }
+            , alignRight : Bool
         }
     -> Element msg
-headerToElement renderConfig { label, openMsg, width, size, sorting, applied } =
+headerToElement renderConfig { label, openMsg, width, size, sorting, applied, alignRight } =
     let
         { padding, fontSize, iconSize } =
             headerProportions size
@@ -105,6 +102,7 @@ headerToElement renderConfig { label, openMsg, width, size, sorting, applied } =
                    , Element.onEnterPressed openMsg
                    , Element.tabIndex 0
                    ]
+                    |> prependIf alignRight Element.alignRight
 
         headerSortingIcon =
             sorting
@@ -185,9 +183,10 @@ bodyToElement :
             , rows : RenderConfig -> FilterSize -> List (Element msg)
             , rowsHeight : Maybe Int
             , buttons : RenderConfig -> List (Button msg)
+            , alignRight : Bool
         }
     -> Element msg
-bodyToElement renderConfig { label, closeMsg, width, size, sorting, rows, buttons, rowsHeight } =
+bodyToElement renderConfig { label, closeMsg, width, size, sorting, rows, buttons, rowsHeight, alignRight } =
     let
         attrs =
             if width == fill then
@@ -212,6 +211,7 @@ bodyToElement renderConfig { label, closeMsg, width, size, sorting, rows, button
             , Border.color Colors.gray300
             , roundedBorders
             ]
+            |> prependIf alignRight Element.alignRight
 
         bodyAttrs =
             [ Element.width fill
@@ -536,6 +536,7 @@ defaultFilter :
     , clearSortingMsg : msg
     , label : String
     , isOpen : Bool
+    , alignRight : Bool
     }
     -> Filter msg item
     -> Maybe (Sorter.Status item)
@@ -591,6 +592,7 @@ defaultFilter config filter sorting =
             (\i -> { preview = String.fromInt i, clearMsg = config.editMsg Msg.Clear })
             (Model.appliedLength filter)
     , rows = rows
+    , alignRight = config.alignRight
     }
 
 

--- a/src/UI/Internal/Filter/View.elm
+++ b/src/UI/Internal/Filter/View.elm
@@ -8,7 +8,7 @@ import Element.Events as Events
 import Element.Font as Font
 import UI.Button as Button exposing (Button)
 import UI.Icon as Icon
-import UI.Internal.Basics exposing (maybeNotThen)
+import UI.Internal.Basics exposing (maybeNotThen, prependIf)
 import UI.Internal.Colors as Colors
 import UI.Internal.DateInput as DateInput exposing (DateInput(..), PeriodComparison(..), PeriodDate, RangeDate)
 import UI.Internal.Filter.Model as Model exposing (Filter)
@@ -22,7 +22,6 @@ import UI.Size as Size exposing (Size)
 import UI.TextField as TextField exposing (TextField)
 import UI.Utils.ARIA as ARIA
 import UI.Utils.Element as Element exposing (RectangleSides, zeroPadding)
-import UI.Internal.Basics exposing (prependIf)
 
 
 type FilterSize
@@ -66,22 +65,21 @@ headerToElement :
         { h
             | label : String
             , openMsg : msg
-            , width : Element.Length
             , size : FilterSize
             , sorting : Maybe (FilterSorting msg)
             , applied : Maybe { preview : String, clearMsg : msg }
             , alignRight : Bool
         }
     -> Element msg
-headerToElement renderConfig { label, openMsg, width, size, sorting, applied, alignRight } =
+headerToElement renderConfig { label, openMsg, size, sorting, applied, alignRight } =
     let
         { padding, fontSize, iconSize } =
             headerProportions size
 
         attrs =
             ARIA.toElementAttributes ARIA.roleButton
-                ++ [ Element.width width
-                   , Element.paddingEach padding
+                ++ [ Element.paddingEach padding
+                   , Element.width fill
                    , Element.spacing 8
                    , Background.color baseColor
                    , Border.width 2
@@ -102,7 +100,7 @@ headerToElement renderConfig { label, openMsg, width, size, sorting, applied, al
                    , Element.onEnterPressed openMsg
                    , Element.tabIndex 0
                    ]
-                    |> prependIf alignRight Element.alignRight
+                |> prependIf alignRight Element.alignRight
 
         headerSortingIcon =
             sorting
@@ -211,7 +209,7 @@ bodyToElement renderConfig { label, closeMsg, width, size, sorting, rows, button
             , Border.color Colors.gray300
             , roundedBorders
             ]
-            |> prependIf alignRight Element.alignRight
+                |> prependIf alignRight Element.alignRight
 
         bodyAttrs =
             [ Element.width fill
@@ -243,7 +241,7 @@ bodyToElement renderConfig { label, closeMsg, width, size, sorting, rows, button
     Element.column attrs bodyRows
         |> Element.customOverlay closeMsg []
         |> Element.el
-            [ Element.width width
+            [ Element.width fill
             , Element.height (px 1)
             , Element.alignTop
             ]

--- a/src/UI/Internal/Tables/FiltersView.elm
+++ b/src/UI/Internal/Tables/FiltersView.elm
@@ -50,6 +50,7 @@ header renderConfig filter sorting config =
         , sortAscendingMsg = sortMsg SortAscending
         , sortDescendingMsg = sortMsg SortDescending
         , clearSortingMsg = config.fromSortersMsg Sorters.ClearSorting
+        , alignRight = False
         }
         filter
         sorting

--- a/src/UI/ListView.elm
+++ b/src/UI/ListView.elm
@@ -88,7 +88,7 @@ Also, it can optionally filter when having a search bar, and add an action bar.
 
 -}
 
-import Element exposing (Element, fill)
+import Element exposing (Element, fill, shrink)
 import Element.Background as Background
 import Element.Border as Border
 import Element.Events as Events
@@ -635,6 +635,7 @@ selectAllButtonView : RenderConfig -> SelectAll msg -> Element msg
 selectAllButtonView cfg { state, message } =
     Checkbox.checkbox (cfg |> localeTerms >> .listView >> .selectAll) message state
         |> Checkbox.renderElement cfg
+        |> Element.el [ Element.width fill, Element.alignTop ]
 
 
 filterView : RenderConfig -> Filter msg -> Element msg
@@ -643,6 +644,7 @@ filterView cfg filter =
         |> Filter.withSize Filter.sizeExtraSmall
         |> Filter.withAlignRight
         |> Filter.renderElement cfg
+        |> Element.el [ Element.width shrink, Element.alignRight, Element.alignTop ]
 
 
 headerView : RenderConfig -> Options object msg -> Element msg


### PR DESCRIPTION
#### :thinking: What?

- Adds support for additional filters in the `ListView`
  - This change required adding `withAlignRight` to the `UI.Filter`
    - ... and I ended up fixing an unknown issue with the `UI.Filter` button width.

#### :man_shrugging: Why?

~~the voice inside my head asked it~~

Required for [WS-12](https://paacklogistics.atlassian.net/browse/WS-12)

#### 🔍 How it looks like?

Depends on usage, but it looks great like this:

![image](https://user-images.githubusercontent.com/2013206/129565620-8c8629ab-93f6-4e5e-8874-dcc78d0b972e.png)

![image](https://user-images.githubusercontent.com/2013206/129565679-976f3c7c-04d2-410a-a80a-33e6c252e7e8.png)

```elm
-- showcase/src/Layouts/Stories.elm:127
|> ListView.withFilter
    (model.extraFilter
        |> Filter.fromModel "Filters"
            (LayoutsMsg.ForFilter >> Msg.LayoutsStoriesMsg)
        |> Filter.withWidth (Element.minimum 150 Element.fill)
    )
```

~~Though I'm not sure why the checkbox is shrinking there...~~ **FIXED**

#### :pushpin: Jira Issue

[WS-12](https://paacklogistics.atlassian.net/browse/WS-12)

### :fire: Extra

Both I and @PedroHLC are very unhappy with how we have to extend the list view for everything every time.

I wanted to improve that with a modular v2 `ListView`, but it would be a huge change and I'm worried about it requiring more boilerplate for using doing the same stuff we already do...
