### PR TITLE
S4S-109 | Add a new dropdown type which can help build auto-completable elements

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -44,7 +44,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "PaackEng/elm-ui-dropdown": "3.1.1 <= v < 4.0.0",
+        "PaackEng/elm-ui-dropdown": "3.2.0 <= v < 4.0.0",
         "elm/browser": "1.0.2 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",

--- a/showcase/src/Dropdown/Model.elm
+++ b/showcase/src/Dropdown/Model.elm
@@ -7,6 +7,7 @@ import UI.Dropdown as Dropdown
 type alias Model =
     { dropdownState : Dropdown.State Book
     , selectedBook : Maybe Book
+    , filterText : String
     }
 
 
@@ -14,4 +15,5 @@ initModel : Model
 initModel =
     { dropdownState = Dropdown.init "default-dropdown"
     , selectedBook = Nothing
+    , filterText = ""
     }

--- a/showcase/src/Dropdown/Msg.elm
+++ b/showcase/src/Dropdown/Msg.elm
@@ -7,3 +7,4 @@ import UI.Dropdown as Dropdown
 type Msg
     = ForDropdownMsg (Dropdown.Msg Book)
     | SelectMsg (Maybe Book)
+    | FilterTextChanged String


### PR DESCRIPTION
#### :thinking: What?

This PR adds a new dropdown type which can help build auto-completable/type-ahead suggestion elements.

#### :man_shrugging: Why?

We will need such an element with customer-dashboard application.

#### :pushpin: Jira Issue

[S4S-109](https://paacklogistics.atlassian.net/browse/S4S-109)
