### PR TITLE
S4S-110 | Add error text below TextField if it applies

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "6.8.0",
+    "version": "6.8.1",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",

--- a/showcase/src/TextField.elm
+++ b/showcase/src/TextField.elm
@@ -25,6 +25,7 @@ stories cfg =
         , passwordTextFieldStory cfg
         , fullWidthStory cfg
         , unitedStory cfg
+        , errorTextFieldStory cfg
         ]
 
 
@@ -57,6 +58,40 @@ defaultTextFieldCode =
     |> TextField.withPlaceholder "Enter your info here"
     |> TextField.setLabelVisible True
     |> TextField.renderElement renderCfg
+"""
+
+
+errorTextFieldStory : RenderConfig -> ExplorerStory
+errorTextFieldStory cfg =
+    story
+        ( "Input Error"
+        , errorTextFieldView cfg
+        , pluginOptions errorTextFieldCode
+        )
+
+
+errorTextFieldView : RenderConfig -> Element RootMsg.Msg
+errorTextFieldView cfg =
+    TextField.singlelineText (always RootMsg.NoOp)
+        "My input with error"
+        "Value"
+        |> TextField.withPlaceholder "Enter your info here"
+        |> TextField.withError "This field is required"
+        |> TextField.setLabelVisible True
+        |> TextField.renderElement cfg
+
+
+errorTextFieldCode : String
+errorTextFieldCode =
+    """
+TextField.singlelineText (always RootMsg.NoOp)
+    "My input with error"
+    "Value"
+    |> TextField.withPlaceholder "Enter your info here"
+    |> TextField.withError "This field is required"
+    |> TextField.setLabelVisible True
+    |> TextField.renderElement cfg
+
 """
 
 

--- a/src/UI/TextField.elm
+++ b/src/UI/TextField.elm
@@ -467,26 +467,21 @@ renderElement cfg (TextField prop opt) =
                 ContentSinglelineText ->
                     inputAnyOptions cfg msg prop opt
                         |> Input.text elAttrs
-                        |> textFieldError cfg opt.errorCaption
 
                 ContentMultilineText ->
                     inputMultilineOptions cfg msg prop opt
                         |> Input.multiline elAttrs
-                        |> textFieldError cfg opt.errorCaption
 
                 ContentUsername ->
                     inputAnyOptions cfg msg prop opt
                         |> Input.username elAttrs
-                        |> textFieldError cfg opt.errorCaption
 
                 ContentPassword pswOpt ->
                     whenPassword msg pswOpt
-                        |> textFieldError cfg opt.errorCaption
 
                 ContentEmail ->
                     inputAnyOptions cfg msg prop opt
                         |> Input.email elAttrs
-                        |> textFieldError cfg opt.errorCaption
 
                 ContentSearch ->
                     inputAnyOptions cfg msg prop opt
@@ -495,7 +490,6 @@ renderElement cfg (TextField prop opt) =
                 ContentSpellChecked ->
                     inputAnyOptions cfg msg prop opt
                         |> Input.spellChecked elAttrs
-                        |> textFieldError cfg opt.errorCaption
 
         whenStatic value =
             Text.subtitle2 value
@@ -514,6 +508,7 @@ renderElement cfg (TextField prop opt) =
     case prop.changeable of
         Just msg ->
             nonStatic prop.content msg
+                |> textFieldError cfg opt.errorCaption
 
         Nothing ->
             whenStatic prop.currentValue

--- a/src/UI/TextField.elm
+++ b/src/UI/TextField.elm
@@ -98,7 +98,7 @@ import UI.Internal.Colors as Colors
 import UI.Internal.Primitives as Primitives
 import UI.Internal.Size as Size
 import UI.Internal.Text as Text
-import UI.Palette as Palette exposing (brightnessMiddle, toneGray)
+import UI.Palette as Palette exposing (brightnessDarkest, brightnessMiddle, toneDanger, toneGray)
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Size exposing (Size)
 import UI.Text as Text
@@ -247,8 +247,6 @@ setLabelVisible isVisible (TextField prop opt) =
 {-| Replaces the text with an error message and make the border red.
 
     TextField.withError "Minimum eight caracters." someTextField
-
-**NOTE**: Not ready, just make border red by now.
 
 -}
 withError : String -> TextField msg -> TextField msg
@@ -469,21 +467,26 @@ renderElement cfg (TextField prop opt) =
                 ContentSinglelineText ->
                     inputAnyOptions cfg msg prop opt
                         |> Input.text elAttrs
+                        |> textFieldError cfg opt.errorCaption
 
                 ContentMultilineText ->
                     inputMultilineOptions cfg msg prop opt
                         |> Input.multiline elAttrs
+                        |> textFieldError cfg opt.errorCaption
 
                 ContentUsername ->
                     inputAnyOptions cfg msg prop opt
                         |> Input.username elAttrs
+                        |> textFieldError cfg opt.errorCaption
 
                 ContentPassword pswOpt ->
                     whenPassword msg pswOpt
+                        |> textFieldError cfg opt.errorCaption
 
                 ContentEmail ->
                     inputAnyOptions cfg msg prop opt
                         |> Input.email elAttrs
+                        |> textFieldError cfg opt.errorCaption
 
                 ContentSearch ->
                     inputAnyOptions cfg msg prop opt
@@ -492,6 +495,7 @@ renderElement cfg (TextField prop opt) =
                 ContentSpellChecked ->
                     inputAnyOptions cfg msg prop opt
                         |> Input.spellChecked elAttrs
+                        |> textFieldError cfg opt.errorCaption
 
         whenStatic value =
             Text.subtitle2 value
@@ -653,7 +657,7 @@ attrs cfg prop opt =
             opt.errorCaption /= Nothing
 
         isPlaceholder =
-            prop.currentValue /= ""
+            prop.currentValue == ""
 
         eventAttr acu =
             case opt.onEnterPressed of
@@ -721,7 +725,7 @@ genericAttr label isPlaceholder hasError width size =
     , Primitives.roundedBorders size
     , Border.color <|
         if hasError then
-            Colors.red500
+            Colors.red700
 
         else
             Colors.gray300
@@ -745,10 +749,13 @@ genericAttr label isPlaceholder hasError width size =
     , Font.color <|
         -- TODO: Use CSS pre-processor
         if isPlaceholder then
-            Colors.gray800
+            Colors.gray600
+
+        else if hasError && not isPlaceholder then
+            Colors.red700
 
         else
-            Colors.gray600
+            Colors.gray800
     , Element.title label
     ]
 
@@ -785,3 +792,21 @@ textFieldPadding size =
 
         Size.ExtraSmall ->
             Element.paddingXY 8 7
+
+
+textFieldError : RenderConfig -> Maybe String -> Element msg -> Element msg
+textFieldError cfg errorCaption inputElement =
+    case errorCaption of
+        Just caption ->
+            Element.column
+                [ Element.spacing 8 ]
+                [ inputElement
+                , caption
+                    |> Text.caption
+                    |> Text.withColor
+                        (Palette.color toneDanger brightnessDarkest)
+                    |> Text.renderElement cfg
+                ]
+
+        Nothing ->
+            inputElement


### PR DESCRIPTION
#### :thinking: What?

Show error text below a text field if it applies

![input-error](https://user-images.githubusercontent.com/6733537/131877970-8b22941d-4dda-4b65-af07-2691eb0919d5.png)

#### :man_shrugging: Why?

Since it was missing

#### :pushpin: Jira Issue

[S4S-110](https://paacklogistics.atlassian.net/browse/S4S-110)
