### PR TITLE
Adds blur handler in focus config

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "6.9.0",
+    "version": "7.0.0",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",

--- a/src/UI/Utils/Focus.elm
+++ b/src/UI/Utils/Focus.elm
@@ -35,6 +35,7 @@ import Html.Attributes as HtmlAttrs
 -}
 type alias Focus msg =
     { onEnter : msg
+    , onLeave : msg
     , tabIndex : Int
     , hasFocus : Bool
     }
@@ -47,10 +48,11 @@ type alias Focus msg =
 
 -}
 toElementAttributes : Focus msg -> List (Attribute msg)
-toElementAttributes { onEnter, tabIndex, hasFocus } =
+toElementAttributes { onEnter, tabIndex, hasFocus, onLeave } =
     let
         any =
             [ Events.onFocus onEnter
+            , Events.onLoseFocus onLeave
             , tabIndex
                 |> HtmlAttrs.tabindex
                 |> Element.htmlAttribute


### PR DESCRIPTION
#### :thinking: What?

Adds blur handler in focus config

#### :man_shrugging: Why?

Need to show [some suggestion](https://www.figma.com/file/GUqevGHHTKTnZT4VgaXfns/Communications?node-id=900%3A6294) under the `TextField` depending upon the focus status.

#### :pushpin: Jira Issue

Not tracked.
