### PR TITLE
S4S-133 | If an error caption is empty, it shouldn't make TextField borders red

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "7.0.0",
+    "version": "7.0.1",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",

--- a/src/UI/TextField.elm
+++ b/src/UI/TextField.elm
@@ -649,7 +649,9 @@ attrs : RenderConfig -> Properties msg -> Options msg -> List (Attribute msg)
 attrs cfg prop opt =
     let
         hasError =
-            opt.errorCaption /= Nothing
+            opt.errorCaption
+                |> Maybe.map showError
+                |> Maybe.withDefault False
 
         isPlaceholder =
             prop.currentValue == ""
@@ -793,15 +795,26 @@ textFieldError : RenderConfig -> Maybe String -> Element msg -> Element msg
 textFieldError cfg errorCaption inputElement =
     case errorCaption of
         Just caption ->
-            Element.column
-                [ Element.spacing 8 ]
-                [ inputElement
-                , caption
-                    |> Text.caption
-                    |> Text.withColor
-                        Palette.red700
-                    |> Text.renderElement cfg
-                ]
+            if showError caption then
+                Element.column
+                    [ Element.width Element.fill
+                    , Element.spacing 8
+                    ]
+                    [ inputElement
+                    , caption
+                        |> Text.caption
+                        |> Text.withColor
+                            Palette.red700
+                        |> Text.renderElement cfg
+                    ]
+
+            else
+                inputElement
 
         Nothing ->
             inputElement
+
+
+showError : String -> Bool
+showError error =
+    (error |> String.trim |> String.length) > 0

--- a/src/UI/TextField.elm
+++ b/src/UI/TextField.elm
@@ -251,8 +251,20 @@ setLabelVisible isVisible (TextField prop opt) =
 -}
 withError : String -> TextField msg -> TextField msg
 withError caption (TextField prop opt) =
+    let
+        trimmedCaption =
+            String.trim caption
+    in
     TextField prop
-        { opt | errorCaption = Just caption }
+        { opt
+            | errorCaption =
+                case trimmedCaption of
+                    "" ->
+                        Nothing
+
+                    _ ->
+                        Just trimmedCaption
+        }
 
 
 {-| Trigger message when the users press return-key while editing the text field.
@@ -649,9 +661,7 @@ attrs : RenderConfig -> Properties msg -> Options msg -> List (Attribute msg)
 attrs cfg prop opt =
     let
         hasError =
-            opt.errorCaption
-                |> Maybe.map showError
-                |> Maybe.withDefault False
+            opt.errorCaption /= Nothing
 
         isPlaceholder =
             prop.currentValue == ""
@@ -795,26 +805,17 @@ textFieldError : RenderConfig -> Maybe String -> Element msg -> Element msg
 textFieldError cfg errorCaption inputElement =
     case errorCaption of
         Just caption ->
-            if showError caption then
-                Element.column
-                    [ Element.width Element.fill
-                    , Element.spacing 8
-                    ]
-                    [ inputElement
-                    , caption
-                        |> Text.caption
-                        |> Text.withColor
-                            Palette.red700
-                        |> Text.renderElement cfg
-                    ]
-
-            else
-                inputElement
+            Element.column
+                [ Element.width Element.fill
+                , Element.spacing 8
+                ]
+                [ inputElement
+                , caption
+                    |> Text.caption
+                    |> Text.withColor
+                        Palette.red700
+                    |> Text.renderElement cfg
+                ]
 
         Nothing ->
             inputElement
-
-
-showError : String -> Bool
-showError error =
-    (error |> String.trim |> String.length) > 0

--- a/src/UI/TextField.elm
+++ b/src/UI/TextField.elm
@@ -803,19 +803,19 @@ textFieldPadding size =
 
 textFieldError : RenderConfig -> Maybe String -> Element msg -> Element msg
 textFieldError cfg errorCaption inputElement =
-    case errorCaption of
-        Just caption ->
-            Element.column
-                [ Element.width Element.fill
-                , Element.spacing 8
-                ]
-                [ inputElement
-                , caption
+    Element.column
+        [ Element.width Element.fill
+        , Element.spacing 8
+        ]
+        [ inputElement
+        , case errorCaption of
+            Just caption ->
+                caption
                     |> Text.caption
                     |> Text.withColor
                         Palette.red700
                     |> Text.renderElement cfg
-                ]
 
-        Nothing ->
-            inputElement
+            Nothing ->
+                Element.none
+        ]


### PR DESCRIPTION
#### :thinking: What?

Stops making borders red if error caption is an empty string

#### :man_shrugging: Why?

I had an `error` filed in my model of type `Maybe String`, for `Nothing` values of `error`, I was seeing red borders. Here is a code sample:

```elm
TextField.singlelineText Msg "Label" "value"
    |> TextField.withError (error |> Maybe.map identity |> Maybe.withDefault ""
```

#### :pushpin: Jira Issue

https://paacklogistics.atlassian.net/browse/S4S-133
