### PR TITLE
S4S-166 | Add dropdown customizations

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "7.2.0",
+    "version": "7.3.0",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",


### PR DESCRIPTION
#### :thinking: What?

Allows customizing the followings:

- Width of the dropdown list
- Alignment of the dropdown list
- Prompt text

#### :man_shrugging: Why?

Because I had to match this [design](https://www.figma.com/file/GUqevGHHTKTnZT4VgaXfns/Communications?node-id=900%3A7945).


![Screenshot_20210929_185915](https://user-images.githubusercontent.com/6733537/135283595-7124477b-3502-4541-908f-32fa64fbfe77.png)

#### :pushpin: Jira Issue

[S4S-166](https://paacklogistics.atlassian.net/browse/S4S-166)