### PR TITLE
Add inline alerts

### DIFF
--- a/showcase/src/Alerts.elm
+++ b/showcase/src/Alerts.elm
@@ -3,11 +3,12 @@ module Alerts exposing (stories)
 import Element exposing (Element, fill)
 import PluginOptions exposing (PluginOptions, defaultWithMenu)
 import UI.Alert as Alert
+import UI.Palette as Palette
 import UI.RenderConfig exposing (RenderConfig)
+import UI.Text as Text
 import UIExplorer exposing (storiesOf)
 import Utils exposing (ExplorerStory, ExplorerUI, goToDocsCallToAction, iconsSvgSprite, prettifyElmCode, story)
-import UI.Text as Text
-import UI.Palette as Palette
+
 
 stories : RenderConfig -> ExplorerUI
 stories renderConfig =
@@ -62,13 +63,13 @@ unitedStory renderConfig =
     story
         ( "United"
         , Element.column [ Element.width fill, Element.spacing 40 ]
-            [   Element.column [ Element.width fill, Element.spacing 20 ][
-                    Element.column [ Element.width fill, Element.spacing 8 ]
-                        [ Text.overline "FULL BLEED ALERTS"
-                            |>Text.withColor Palette.gray700
-                            |> Text.renderElement renderConfig
-                        ]
-                    ,Element.column [ Element.width fill, Element.spacing 8 ]
+            [ Element.column [ Element.width fill, Element.spacing 20 ]
+                [ Element.column [ Element.width fill, Element.spacing 8 ]
+                    [ Text.overline "FULL BLEED ALERTS"
+                        |> Text.withColor Palette.gray700
+                        |> Text.renderElement renderConfig
+                    ]
+                , Element.column [ Element.width fill, Element.spacing 8 ]
                     [ iconsSvgSprite
                     , alert Alert.primary renderConfig
                     , alert Alert.success renderConfig
@@ -79,13 +80,13 @@ unitedStory renderConfig =
                     , alertWithIcon Alert.danger renderConfig
                     ]
                 ]
-                ,Element.column [ Element.width fill, Element.spacing 20 ]
-                [   Element.column [ Element.width fill, Element.spacing 8 ]
+            , Element.column [ Element.width fill, Element.spacing 20 ]
+                [ Element.column [ Element.width fill, Element.spacing 8 ]
                     [ Text.overline "INLINE ALERTS"
-                        |>Text.withColor Palette.gray700
+                        |> Text.withColor Palette.gray700
                         |> Text.renderElement renderConfig
                     ]
-                    ,Element.column [ Element.width fill, Element.spacing 8 ]
+                , Element.column [ Element.width fill, Element.spacing 8 ]
                     [ iconsSvgSprite
                     , inlineAlert Alert.primary renderConfig
                     , inlineAlert Alert.success renderConfig
@@ -113,11 +114,13 @@ alertWithIcon alertFn renderConfig =
         |> Alert.withGenericIcon
         |> Alert.renderElement renderConfig
 
+
 inlineAlert : (String -> Alert.Alert msg) -> RenderConfig -> Element msg
 inlineAlert alertFn renderConfig =
     alertFn "I'm an inline alert !"
         |> Alert.withInlineStyle
         |> Alert.renderElement renderConfig
+
 
 inlineAlertWithGenericIcon : (String -> Alert.Alert msg) -> RenderConfig -> Element msg
 inlineAlertWithGenericIcon alertFn renderConfig =

--- a/showcase/src/Alerts.elm
+++ b/showcase/src/Alerts.elm
@@ -116,13 +116,13 @@ alertWithIcon alertFn renderConfig =
 inlineAlert : (String -> Alert.Alert msg) -> RenderConfig -> Element msg
 inlineAlert alertFn renderConfig =
     alertFn "I'm an inline alert !"
-        |> Alert.isInline
+        |> Alert.withInlineStyle
         |> Alert.renderElement renderConfig
 
 inlineAlertWithGenericIcon : (String -> Alert.Alert msg) -> RenderConfig -> Element msg
 inlineAlertWithGenericIcon alertFn renderConfig =
     alertFn "I'm an inline alert !"
-        |> Alert.isInline
+        |> Alert.withInlineStyle
         |> Alert.withGenericIcon
         |> Alert.renderElement renderConfig
 

--- a/showcase/src/Alerts.elm
+++ b/showcase/src/Alerts.elm
@@ -6,7 +6,8 @@ import UI.Alert as Alert
 import UI.RenderConfig exposing (RenderConfig)
 import UIExplorer exposing (storiesOf)
 import Utils exposing (ExplorerStory, ExplorerUI, goToDocsCallToAction, iconsSvgSprite, prettifyElmCode, story)
-
+import UI.Text as Text
+import UI.Palette as Palette
 
 stories : RenderConfig -> ExplorerUI
 stories renderConfig =
@@ -60,15 +61,41 @@ unitedStory : RenderConfig -> ExplorerStory
 unitedStory renderConfig =
     story
         ( "United"
-        , Element.column [ Element.width fill, Element.spacing 8 ]
-            [ iconsSvgSprite
-            , alert Alert.primary renderConfig
-            , alert Alert.success renderConfig
-            , alert Alert.warning renderConfig
-            , alert Alert.danger renderConfig
-            , alertWithIcon Alert.success renderConfig
-            , alertWithIcon Alert.warning renderConfig
-            , alertWithIcon Alert.danger renderConfig
+        , Element.column [ Element.width fill, Element.spacing 40 ]
+            [   Element.column [ Element.width fill, Element.spacing 20 ][
+                    Element.column [ Element.width fill, Element.spacing 8 ]
+                        [ Text.overline "FULL BLEED ALERTS"
+                            |>Text.withColor Palette.gray700
+                            |> Text.renderElement renderConfig
+                        ]
+                    ,Element.column [ Element.width fill, Element.spacing 8 ]
+                    [ iconsSvgSprite
+                    , alert Alert.primary renderConfig
+                    , alert Alert.success renderConfig
+                    , alert Alert.warning renderConfig
+                    , alert Alert.danger renderConfig
+                    , alertWithIcon Alert.success renderConfig
+                    , alertWithIcon Alert.warning renderConfig
+                    , alertWithIcon Alert.danger renderConfig
+                    ]
+                ]
+                ,Element.column [ Element.width fill, Element.spacing 20 ]
+                [   Element.column [ Element.width fill, Element.spacing 8 ]
+                    [ Text.overline "INLINE ALERTS"
+                        |>Text.withColor Palette.gray700
+                        |> Text.renderElement renderConfig
+                    ]
+                    ,Element.column [ Element.width fill, Element.spacing 8 ]
+                    [ iconsSvgSprite
+                    , inlineAlert Alert.primary renderConfig
+                    , inlineAlert Alert.success renderConfig
+                    , inlineAlert Alert.warning renderConfig
+                    , inlineAlert Alert.danger renderConfig
+                    , inlineAlertWithGenericIcon Alert.success renderConfig
+                    , inlineAlertWithGenericIcon Alert.warning renderConfig
+                    , inlineAlertWithGenericIcon Alert.danger renderConfig
+                    ]
+                ]
             ]
         , defaultWithMenu
         )
@@ -83,6 +110,19 @@ alert alertFn renderConfig =
 alertWithIcon : (String -> Alert.Alert msg) -> RenderConfig -> Element msg
 alertWithIcon alertFn renderConfig =
     alertFn "I have an icon."
+        |> Alert.withGenericIcon
+        |> Alert.renderElement renderConfig
+
+inlineAlert : (String -> Alert.Alert msg) -> RenderConfig -> Element msg
+inlineAlert alertFn renderConfig =
+    alertFn "I'm an inline alert !"
+        |> Alert.isInline
+        |> Alert.renderElement renderConfig
+
+inlineAlertWithGenericIcon : (String -> Alert.Alert msg) -> RenderConfig -> Element msg
+inlineAlertWithGenericIcon alertFn renderConfig =
+    alertFn "I'm an inline alert !"
+        |> Alert.isInline
         |> Alert.withGenericIcon
         |> Alert.renderElement renderConfig
 

--- a/src/UI/Alert.elm
+++ b/src/UI/Alert.elm
@@ -1,6 +1,7 @@
 module UI.Alert exposing
     ( Alert, primary, success, warning, danger
     , withGenericIcon
+    , isInline
     , renderElement
     )
 
@@ -40,6 +41,8 @@ import UI.Palette as Palette
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Size as Size
 import UI.Text as Text
+import Element.Border
+import UI.Internal.Primitives as Primitives
 
 
 type alias Properties =
@@ -49,7 +52,8 @@ type alias Properties =
 
 
 type alias Options =
-    { genericIcon : Bool
+    { genericIcon : Bool,
+      inline : Bool  
     }
 
 
@@ -126,12 +130,16 @@ withGenericIcon : Alert msg -> Alert msg
 withGenericIcon (Alert prop opt) =
     Alert prop { opt | genericIcon = True }
 
+isInline : Alert msg -> Alert msg
+isInline (Alert prop opt) =
+    Alert prop { opt | inline = True }
+
 
 {-| End of the builder's life.
 The result of this function is a ready-to-insert Elm UI's Element.
 -}
 renderElement : RenderConfig -> Alert msg -> Element msg
-renderElement cfg (Alert { title, tone } { genericIcon }) =
+renderElement cfg (Alert { title, tone } { genericIcon, inline }) =
     let
         color =
             getTextColor tone
@@ -150,6 +158,9 @@ renderElement cfg (Alert { title, tone } { genericIcon }) =
             |> Palette.toElementColor
             |> Background.color
         , Element.alignTop
+        , if inline then
+            Primitives.roundedBorders Size.medium
+            else Element.Border.rounded 0
         ]
         [ Text.subtitle2 title
             |> Text.withColor color
@@ -157,7 +168,6 @@ renderElement cfg (Alert { title, tone } { genericIcon }) =
             |> Element.el [ Element.centerY, Element.width fill ]
         , if genericIcon then
             icon cfg tone color
-
           else
             Element.none
         ]
@@ -169,7 +179,7 @@ renderElement cfg (Alert { title, tone } { genericIcon }) =
 
 defaultOptions : Options
 defaultOptions =
-    { genericIcon = False }
+    { genericIcon = False, inline = False }
 
 
 getTextColor : AlertTone -> Palette.Color

--- a/src/UI/Alert.elm
+++ b/src/UI/Alert.elm
@@ -1,8 +1,8 @@
 module UI.Alert exposing
     ( Alert, primary, success, warning, danger
     , withGenericIcon
-    , isInline
     , renderElement
+    , isInline
     )
 
 {-| The `UI.Alert` is a component for displaying feedback in a full-width banner.
@@ -36,13 +36,13 @@ An alert can be created and render as in the following pipeline:
 
 import Element exposing (Element, fill, px)
 import Element.Background as Background
+import Element.Border
 import UI.Icon as Icon
+import UI.Internal.Primitives as Primitives
 import UI.Palette as Palette
 import UI.RenderConfig exposing (RenderConfig)
 import UI.Size as Size
 import UI.Text as Text
-import Element.Border
-import UI.Internal.Primitives as Primitives
 
 
 type alias Properties =
@@ -52,8 +52,8 @@ type alias Properties =
 
 
 type alias Options =
-    { genericIcon : Bool,
-      inline : Bool  
+    { genericIcon : Bool
+    , inline : Bool
     }
 
 
@@ -130,6 +130,7 @@ withGenericIcon : Alert msg -> Alert msg
 withGenericIcon (Alert prop opt) =
     Alert prop { opt | genericIcon = True }
 
+
 isInline : Alert msg -> Alert msg
 isInline (Alert prop opt) =
     Alert prop { opt | inline = True }
@@ -160,7 +161,9 @@ renderElement cfg (Alert { title, tone } { genericIcon, inline }) =
         , Element.alignTop
         , if inline then
             Primitives.roundedBorders Size.medium
-            else Element.Border.rounded 0
+
+          else
+            Element.Border.rounded 0
         ]
         [ Text.subtitle2 title
             |> Text.withColor color
@@ -168,6 +171,7 @@ renderElement cfg (Alert { title, tone } { genericIcon, inline }) =
             |> Element.el [ Element.centerY, Element.width fill ]
         , if genericIcon then
             icon cfg tone color
+
           else
             Element.none
         ]

--- a/src/UI/Alert.elm
+++ b/src/UI/Alert.elm
@@ -2,7 +2,7 @@ module UI.Alert exposing
     ( Alert, primary, success, warning, danger
     , withGenericIcon
     , renderElement
-    , isInline
+    , withInlineStyle
     )
 
 {-| The `UI.Alert` is a component for displaying feedback in a full-width banner.
@@ -131,8 +131,8 @@ withGenericIcon (Alert prop opt) =
     Alert prop { opt | genericIcon = True }
 
 
-isInline : Alert msg -> Alert msg
-isInline (Alert prop opt) =
+withInlineStyle : Alert msg -> Alert msg
+withInlineStyle (Alert prop opt) =
     Alert prop { opt | inline = True }
 
 

--- a/src/UI/Alert.elm
+++ b/src/UI/Alert.elm
@@ -1,8 +1,7 @@
 module UI.Alert exposing
     ( Alert, primary, success, warning, danger
-    , withGenericIcon
+    , withGenericIcon, withInlineStyle
     , renderElement
-    , withInlineStyle
     )
 
 {-| The `UI.Alert` is a component for displaying feedback in a full-width banner.
@@ -25,7 +24,7 @@ An alert can be created and render as in the following pipeline:
 
 # Optional
 
-@docs withGenericIcon
+@docs withGenericIcon, withInlineStyle
 
 
 # Rendering
@@ -131,6 +130,8 @@ withGenericIcon (Alert prop opt) =
     Alert prop { opt | genericIcon = True }
 
 
+{-| Inline style makes the alert's corners rounded
+-}
 withInlineStyle : Alert msg -> Alert msg
 withInlineStyle (Alert prop opt) =
     Alert prop { opt | inline = True }


### PR DESCRIPTION
#### :thinking: What?

Inline options for displaying alerts

#### :man_shrugging: Why?

For some use cases, the edge to edge version of the alert doesn't fit nicely in the UI. With this version, we can explore newer placements of the alert component, without covering the entire screen (this is also very useful for showing contextual info sometimes).

#### :pushpin: Jira Issue

Not tracked.

#### :no_good: Blocked by

Nothing.
