### PR TITLE
S4S-299 | Fix dialog vertical centering

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "7.8.1",
+    "version": "7.8.2",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",

--- a/src/UI/Document.elm
+++ b/src/UI/Document.elm
@@ -88,6 +88,7 @@ import UI.Internal.LegacySideBar as LegacySideBar
 import UI.Internal.Menu as Menu
 import UI.Internal.Page as Internal
 import UI.Internal.SideBar as SideBar
+import UI.Internal.Utils.Element exposing (style)
 import UI.Link exposing (Link)
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
 import UI.Utils.Action as Action
@@ -600,13 +601,23 @@ toBrowserDocument cfg pageItem (Document model) =
                 Nothing ->
                     Element.none
 
+        bodywithDialogBaseAttrs =
+            [ Element.inFront dialogView
+            , Element.width fill
+            , Element.height fill
+            ]
+
+        bodyWithDialogAttrs =
+            if dialogView == Element.none then
+                bodywithDialogBaseAttrs
+
+            else
+                style "max-height" "100vh" :: Element.clipY :: bodywithDialogBaseAttrs
+
         bodyWithDialog =
             -- Always creating this element is required so we don't loose scrollbar state
             Element.el
-                [ Element.inFront dialogView
-                , Element.width fill
-                , Element.height fill
-                ]
+                bodyWithDialogAttrs
                 body
 
         defaultAttrs =

--- a/src/UI/Document.elm
+++ b/src/UI/Document.elm
@@ -601,7 +601,7 @@ toBrowserDocument cfg pageItem (Document model) =
                 Nothing ->
                     Element.none
 
-        bodywithDialogBaseAttrs =
+        bodyWithDialogBaseAttrs =
             [ Element.inFront dialogView
             , Element.width fill
             , Element.height fill
@@ -609,10 +609,10 @@ toBrowserDocument cfg pageItem (Document model) =
 
         bodyWithDialogAttrs =
             if dialogView == Element.none then
-                bodywithDialogBaseAttrs
+                bodyWithDialogBaseAttrs
 
             else
-                style "max-height" "100vh" :: Element.clipY :: bodywithDialogBaseAttrs
+                style "max-height" "100vh" :: Element.clipY :: bodyWithDialogBaseAttrs
 
         bodyWithDialog =
             -- Always creating this element is required so we don't loose scrollbar state


### PR DESCRIPTION
#### :thinking: What?

Vertically centers dialog irrespective of the height of the page it is rendered in

#### :man_shrugging: Why?

Dialog was not centered if the contents of the page had a height more than `100vh`, Sergio reported it [here](https://paack.slack.com/archives/C020YT55GNB/p1637222453003000).

#### :pushpin: Jira Issue

[S4S-299](https://paacklogistics.atlassian.net/browse/S4S-299)

### :fire: Extra

@niqt approached this problem using css positions, he opened #332 to fix this problem. I tested this approach later and discussed it with @niqt, and we decided to open two different PR's, and let the team decide which way to go. Thanks
