### PR TITLE
WS-544 | LMO-1407 | Add dropdown `Menu` component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @miguelcoba @PedroHLC @renanpvaz @segmentationfaulter @kress95 @niqt
+* @PedroHLC @segmentationfaulter @kress95 @niqt @sufiyanyusuf

--- a/elm.json
+++ b/elm.json
@@ -19,6 +19,7 @@
         "UI.Icon",
         "UI.Link",
         "UI.LoadingView",
+        "UI.Menu",
         "UI.Paginator",
         "UI.Palette",
         "UI.Radio",

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "7.10.0",
+    "version": "7.11.0",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@percy/cli": "^1.0.0-beta.70",
     "@percy/cypress": "^3.1.1",
-    "cypress": "^9.0.0",
+    "cypress": "^9.2.0",
     "elm": "^0.19.1-5",
     "elm-format": "^0.8.5",
     "elm-hot": "^1.1.6",

--- a/showcase/src/Main.elm
+++ b/showcase/src/Main.elm
@@ -12,6 +12,7 @@ import Html exposing (Html, div, img)
 import Html.Attributes exposing (src, style)
 import Icons
 import LoadingView
+import Menu.Stories as Menu
 import Model exposing (Model)
 import Msg exposing (Msg(..))
 import Paginators.Stories as Paginators
@@ -114,6 +115,7 @@ main =
             , Dialog.stories renderConfig
             , TextField.stories renderConfig
             , LoadingView.stories
+            , Menu.stories renderConfig
             , Checkboxes.stories renderConfig
             , Switches.stories renderConfig
             , Radio.stories renderConfig
@@ -201,6 +203,10 @@ updateStories msg ({ customModel } as model) =
         FiltersStoriesMsg subMsg ->
             Filters.update subMsg customModel.filtersStories
                 |> R.map (\t -> { model | customModel = { customModel | filtersStories = t } })
+
+        MenuStoriesMsg subMsg ->
+            Menu.update subMsg customModel.menuStories
+                |> R.map (\t -> { model | customModel = { customModel | menuStories = t } })
 
         NoOp ->
             ( model, Cmd.none )

--- a/showcase/src/Menu/Model.elm
+++ b/showcase/src/Menu/Model.elm
@@ -1,0 +1,12 @@
+module Menu.Model exposing (Model, initModel)
+
+
+type alias Model =
+    { isVisible : Bool
+    }
+
+
+initModel : Model
+initModel =
+    { isVisible = False
+    }

--- a/showcase/src/Menu/Msg.elm
+++ b/showcase/src/Menu/Msg.elm
@@ -1,0 +1,5 @@
+module Menu.Msg exposing (Msg(..))
+
+
+type Msg
+    = ToggleMenu

--- a/showcase/src/Menu/Stories.elm
+++ b/showcase/src/Menu/Stories.elm
@@ -1,6 +1,6 @@
 module Menu.Stories exposing (stories, update)
 
-import Element exposing (Element, fill, maximum)
+import Element exposing (Element, fill)
 import Menu.Model as Menu
 import Menu.Msg as Menu
 import Model exposing (Model)
@@ -10,7 +10,6 @@ import Return exposing (Return)
 import UI.Button as Button
 import UI.Icon as Icon
 import UI.Menu as Menu
-import UI.Palette as Palette
 import UI.RenderConfig exposing (RenderConfig)
 import UIExplorer exposing (storiesOf)
 import Utils
@@ -67,12 +66,12 @@ view renderConfig { menuStories } =
             |> Button.cmd toggleMenuMsg Button.primary
             |> Menu.menu toggleMenuMsg
                 [ "Edit"
-                    |> Menu.item toggleMenuMsg Icon.edit
+                    |> Menu.item toggleMenuMsg Nothing
                 , "Download"
-                    |> Menu.item toggleMenuMsg Icon.download
+                    |> Menu.item toggleMenuMsg (Just Icon.download)
                 , "Delete"
-                    |> Menu.item toggleMenuMsg Icon.delete
-                    |> Menu.itemWithColor Palette.red700
+                    |> Menu.item toggleMenuMsg (Just Icon.delete)
+                    |> Menu.itemWithDangerTone
                 ]
             |> Menu.setVisible menuStories.isVisible
             |> Menu.renderElement renderConfig
@@ -88,12 +87,12 @@ menuCode =
         |> Button.cmd toggleMenuMsg Button.primary
         |> Menu.menu toggleMenuMsg
             [ "Edit"
-                |> Menu.item toggleMenuMsg Icon.edit
+                |> Menu.item toggleMenuMsg (Just Icon.edit)
             , "Download"
-                |> Menu.item toggleMenuMsg Icon.download
+                |> Menu.item toggleMenuMsg (Just Icon.download)
             ,  "Delete"
-                |> Menu.item toggleMenuMsg Icon.delete
-                |> Menu.itemWithColor Palette.red700
+                |> Menu.item toggleMenuMsg (Just Icon.delete)
+                |> Menu.itemWithDangerTone
             ]
         |> Menu.setVisible menuStories.isVisible
         |> Menu.renderElement renderConfig

--- a/showcase/src/Menu/Stories.elm
+++ b/showcase/src/Menu/Stories.elm
@@ -1,0 +1,100 @@
+module Menu.Stories exposing (stories, update)
+
+import Element exposing (Element, fill, maximum)
+import Menu.Model as Menu
+import Menu.Msg as Menu
+import Model exposing (Model)
+import Msg exposing (Msg)
+import PluginOptions exposing (defaultWithoutMenu)
+import Return exposing (Return)
+import UI.Button as Button
+import UI.Icon as Icon
+import UI.Menu as Menu
+import UI.Palette as Palette
+import UI.RenderConfig exposing (RenderConfig)
+import UIExplorer exposing (storiesOf)
+import Utils
+    exposing
+        ( ExplorerStory
+        , ExplorerUI
+        , goToDocsCallToAction
+        , iconsSvgSprite
+        , prettifyElmCode
+        , storyWithModel
+        )
+
+
+update : Menu.Msg -> Menu.Model -> Return Msg.Msg Menu.Model
+update msg model =
+    case msg of
+        Menu.ToggleMenu ->
+            ( { model | isVisible = not model.isVisible }, Cmd.none )
+
+
+stories : RenderConfig -> ExplorerUI
+stories renderConfig =
+    storiesOf
+        "Menu"
+        [ menuDemo renderConfig
+        ]
+
+
+menuDemo : RenderConfig -> ExplorerStory
+menuDemo renderConfig =
+    storyWithModel
+        ( "Menu"
+        , view renderConfig
+        , { defaultWithoutMenu
+            | code = menuCode
+            , note = goToDocsCallToAction "Menu"
+          }
+        )
+
+
+toggleMenuMsg : Msg
+toggleMenuMsg =
+    Msg.MenuStoriesMsg Menu.ToggleMenu
+
+
+view : RenderConfig -> Model -> Element Msg
+view renderConfig { menuStories } =
+    Element.column
+        [ Element.spacing 8, Element.width fill ]
+        [ iconsSvgSprite
+        , "Menu"
+            |> Icon.sandwichMenu
+            |> Button.fromIcon
+            |> Button.cmd toggleMenuMsg Button.primary
+            |> Menu.menu toggleMenuMsg
+                [ "Edit"
+                    |> Menu.item toggleMenuMsg Icon.edit
+                , "Download"
+                    |> Menu.item toggleMenuMsg Icon.download
+                , "Delete"
+                    |> Menu.item toggleMenuMsg Icon.delete
+                    |> Menu.itemWithColor Palette.red700
+                ]
+            |> Menu.setVisible menuStories.isVisible
+            |> Menu.renderElement renderConfig
+        ]
+
+
+menuCode : String
+menuCode =
+    prettifyElmCode """
+    "Menu"
+        |> Icon.sandwichMenu
+        |> Button.fromIcon
+        |> Button.cmd toggleMenuMsg Button.primary
+        |> Menu.menu toggleMenuMsg
+            [ "Edit"
+                |> Menu.item toggleMenuMsg Icon.edit
+            , "Download"
+                |> Menu.item toggleMenuMsg Icon.download
+            ,  "Delete"
+                |> Menu.item toggleMenuMsg Icon.delete
+                |> Menu.itemWithColor Palette.red700
+            ]
+        |> Menu.setVisible menuStories.isVisible
+        |> Menu.renderElement renderConfig
+"""

--- a/showcase/src/Model.elm
+++ b/showcase/src/Model.elm
@@ -7,6 +7,7 @@ import Buttons.Model as Buttons
 import Checkboxes.Model as Checkboxes
 import Dropdown.Model as Dropdown
 import Filters.Model as Filters
+import Menu.Model as Menu
 import Paginators.Model as Paginators
 import Radio.Model as Radio
 import Sidebar.Model as Sidebar
@@ -22,14 +23,15 @@ type alias Model =
     , checkboxesStories : Checkboxes.Model
     , dropdownStories : Dropdown.Model
     , filtersStories : Filters.Model
+    , menuStories : Menu.Model
     , paginatorsStories : Paginators.Model
     , radioStories : Radio.Model
     , sidebarStories : Sidebar.Model
     , switchesStories : Switches.Model
     , tablesStories : Tables.Model
+    , tabs : TabsPlugin.Model
     , tabsStories : Tabs.Model
     , tileStories : Tile.Model
-    , tabs : TabsPlugin.Model
     }
 
 
@@ -39,12 +41,13 @@ init =
     , checkboxesStories = Checkboxes.initModel
     , dropdownStories = Dropdown.initModel
     , filtersStories = Filters.initModel
+    , menuStories = Menu.initModel
     , paginatorsStories = Paginators.initModel
     , radioStories = Radio.initModel
     , sidebarStories = Sidebar.initModel
     , switchesStories = Switches.initModel
     , tablesStories = Tables.initModel
+    , tabs = TabsPlugin.initialModel
     , tabsStories = Tabs.initModel
     , tileStories = Tile.initModel
-    , tabs = TabsPlugin.initialModel
     }

--- a/showcase/src/Msg.elm
+++ b/showcase/src/Msg.elm
@@ -4,6 +4,7 @@ import Buttons.Msg as Buttons
 import Checkboxes.Msg as Checkboxes
 import Dropdown.Msg as Dropdown
 import Filters.Msg as Filters
+import Menu.Msg as Menu
 import Paginators.Msg as Paginators
 import Radio.Msg as Radio
 import Sidebar.Msg as Sidebar
@@ -19,6 +20,7 @@ type Msg
     | CheckboxesStoriesMsg Checkboxes.Msg
     | DropdownStoriesMsg Dropdown.Msg
     | FiltersStoriesMsg Filters.Msg
+    | MenuStoriesMsg Menu.Msg
     | PaginatorsStoriesMsg Paginators.Msg
     | RadioStoriesMsg Radio.Msg
     | SidebarStoriesMsg Sidebar.Msg

--- a/src/UI/Menu.elm
+++ b/src/UI/Menu.elm
@@ -15,9 +15,8 @@ A menu can be created and rendered as in the following pipeline:
     Button.cmd ToggleMenu Button.primary
         |> Menu.menu ToggleMenu
             [ Menu.item Download
-                { icon = Icon.download
-                , title = "Download"
-                }
+                Icon.download
+                "Download"
             ]
         |> Menu.renderElement renderConfig
 
@@ -80,7 +79,7 @@ type MenuItem msg
 
 type alias InternalMenuItem msg =
     { color : Maybe Color
-    , icon : Maybe (String -> Icon)
+    , icon : String -> Icon
     , title : String
     , onClick : msg
     }
@@ -91,15 +90,14 @@ type alias InternalMenuItem msg =
     Button.cmd ToggleMenu Button.primary
         |> Menu.menu ToggleMenu
             [ Menu.item Download
-                { icon = Icon.download
-                , title = "Download"
-                }
+                Icon.download
+                "Download"
             ]
         |> Menu.renderElement renderConfig
 
 -}
-item : msg -> { icon : Maybe (String -> Icon), title : String } -> MenuItem msg
-item onToggle { icon, title } =
+item : msg -> (String -> Icon) -> String -> MenuItem msg
+item onToggle icon title =
     MenuItem { onClick = onToggle, icon = icon, title = title, color = Nothing }
 
 
@@ -107,10 +105,8 @@ item onToggle { icon, title } =
 
     Button.cmd ToggleMenu Button.primary
         |> Menu.menu ToggleMenu
-            [ Menu.item Delete
-                { icon = Icon.delete
-                , title = "Delete"
-                }
+            [ "Delete"
+                |> Menu.item Delete Icon.delete
                 |> Menu.itemWithColor Palette.red700
             ]
         |> Menu.renderElement renderConfig
@@ -125,14 +121,10 @@ itemWithColor color (MenuItem menuItem) =
 
     Button.cmd ToggleMenu Button.primary
         |> Menu.menu ToggleMenu
-            [ Menu.item Download
-                { icon = Just Icon.download
-                , title = "Download"
-                }
-            , Menu.item Delete
-                { icon = Just Icon.delete
-                , title = "Delete"
-                }
+            [ "Download"
+                |> Menu.item Download Icon.download
+            , "Delete"
+                |> Menu.item Delete Icon.delete
                 |> Menu.itemWithColor Palette.red700
             ]
         |> Menu.renderElement renderConfig
@@ -227,30 +219,25 @@ renderMenu renderConfig items onToggle =
 
 
 renderEntry : RenderConfig -> MenuItem msg -> Element msg
-renderEntry renderConfig (MenuItem menuItem) =
+renderEntry renderConfig (MenuItem { onClick, icon, title, color }) =
     Element.row
         (Element.padding 8
             :: Element.alignTop
             :: Element.spacing 5
             :: Element.width Element.fill
-            :: Events.onClick menuItem.onClick
+            :: Events.onClick onClick
             :: Element.mouseOver
                 [ Palette.toBackgroundColor Palette.gray300 ]
             :: Border.rounded 3
             :: ARIA.toElementAttributes ARIA.roleButton
         )
-        [ case menuItem.icon of
-            Just icon ->
-                menuItem.title
-                    |> icon
-                    |> Icon.withSize Size.extraSmall
-                    |> Icon.withColor (Maybe.withDefault Palette.blue menuItem.color)
-                    |> Icon.renderElement renderConfig
-                    |> Element.el [ Element.alignTop ]
-
-            Nothing ->
-                Element.none
-        , Text.body2 menuItem.title
-            |> Text.withColor (Maybe.withDefault Palette.blue menuItem.color)
+        [ title
+            |> icon
+            |> Icon.withSize Size.extraSmall
+            |> Icon.withColor (Maybe.withDefault Palette.blue color)
+            |> Icon.renderElement renderConfig
+            |> Element.el [ Element.alignTop ]
+        , Text.body2 title
+            |> Text.withColor (Maybe.withDefault Palette.blue color)
             |> Text.renderElement renderConfig
         ]

--- a/src/UI/Menu.elm
+++ b/src/UI/Menu.elm
@@ -1,9 +1,9 @@
 module UI.Menu exposing
-    ( Menu, item, menu
+    ( Menu, menu
+    , MenuItem, item
     , itemWithColor
     , setVisible
     , renderElement
-    , MenuItem
     )
 
 {-| The `UI.Menu` is a component for rendering dropdown menus.
@@ -24,7 +24,8 @@ A menu can be created and rendered as in the following pipeline:
 
 # Building
 
-@docs Menu, item, menu
+@docs Menu, menu
+@docs MenuItem, item
 
 
 # Style

--- a/src/UI/Menu.elm
+++ b/src/UI/Menu.elm
@@ -1,0 +1,233 @@
+module UI.Menu exposing (Menu, MenuItem, item, menu, setVisible, renderElement)
+
+{-| The `UI.Menu` is a component for rendering dropdown menus.
+
+Following Elm-UI standards, this component is accessible.
+
+A menu can be created and rendered as in the following pipeline:
+
+    Button.cmd ToggleMenu Button.primary
+        |> Menu.menu ToggleMenu
+            [ Menu.item Download
+                { icon = Icon.download
+                , title = "Download"
+                , color = Nothing
+                }
+            ]
+        |> Menu.renderElement renderConfig
+
+# Building
+
+@docs Menu, item, menu
+
+# Interactive
+
+@docs setVisible
+
+
+# Rendering
+
+@docs renderElement
+
+-}
+import Element exposing (Element)
+import Element.Background as Background
+import Element.Border as Border
+import Element.Events as Events
+import Html.Attributes as HtmlAttrs
+import UI.Button as Button exposing (Button)
+import UI.Icon as Icon exposing (Icon)
+import UI.Palette as Palette exposing (Color)
+import UI.RenderConfig exposing (RenderConfig)
+import UI.Size as Size
+import UI.Text as Text
+import UI.Utils.ARIA as ARIA
+
+type alias Properties msg =
+    { button : Button msg
+    , items : List (MenuItem msg)
+    , onToggle : msg
+    , isVisible : Bool
+    }
+
+{-| The `Menu msg` type is used for describing the component for later rendering.
+-}
+type Menu msg
+    = Menu (Properties msg)
+
+{-| The `MenuItem` is required when assembling the list of menu entries.
+-}
+type MenuItem msg
+    = MenuItem (InternalMenuItem msg)
+
+
+type alias InternalMenuItem msg =
+    { color : Maybe Color
+    , icon : Maybe (String -> Icon)
+    , title : String
+    , onClick : msg
+    }
+
+
+{-| Constructs a `MenuItem`.
+
+    Button.cmd ToggleMenu Button.primary
+        |> Menu.menu ToggleMenu
+            [ Menu.item Download
+                { icon = Icon.download
+                , title = "Download"
+                , color = Nothing
+                }
+            ]
+        |> Menu.renderElement renderConfig
+
+-}
+item :
+    msg
+    ->
+        { icon : Maybe (String -> Icon)
+        , title : String
+        , color : Maybe Color
+        }
+    -> MenuItem msg
+item onToggle { icon, title, color } =
+    MenuItem { onClick = onToggle, icon = icon, title = title, color = color }
+
+
+
+
+{-| Defines all the required properties for creating a dropdown menu.
+
+    Button.cmd ToggleMenu Button.primary
+        |> Menu.menu ToggleMenu
+            [ Menu.item Download
+                { icon = Just Icon.download
+                , title = "Download"
+                , color = Nothing
+                }
+            , Menu.item Delete
+                { icon = Just Icon.delete
+                , title = "Delete"
+                , color = Just Palette.red700
+                }
+            ]
+        |> Menu.renderElement renderConfig
+
+-}
+menu : msg -> Button msg -> Menu msg
+menu onToggle button =
+    Menu
+        { button = button
+        , items = []
+        , onToggle = onToggle
+        , isVisible = False
+        }
+
+
+{-| Show or hide the menu overlay.
+
+    Menu.setVisible True someMenu
+
+-}
+setVisible : Bool -> Menu msg -> Menu msg
+setVisible isVisible (Menu state) =
+    Menu { state | isVisible = isVisible }
+
+
+{-| End of the builder's life.
+The result of this function is a ready-to-insert Elm UI's Element.
+-}
+renderElement : RenderConfig -> Menu msg -> Element msg
+renderElement renderConfig (Menu { button, items, onToggle, isVisible }) =
+    button
+        |> Button.renderElement renderConfig
+        |> Element.el
+            (Element.alignRight
+                :: Element.pointer
+                :: Element.alignTop
+                :: (if isVisible then
+                        [ onToggle
+                            |> renderMenu renderConfig items
+                            |> Element.below
+                        ]
+
+                    else
+                        []
+                   )
+            )
+
+
+-- Internals
+
+
+
+
+renderMenu : RenderConfig -> List (MenuItem msg) -> msg -> Element msg
+renderMenu renderConfig items onToggle =
+    let
+        shadow blur =
+            Border.shadow
+                { offset = ( 0, 4 )
+                , size = 0
+                , blur = blur
+                , color = Element.rgba 0 0 0 0.04
+                }
+    in
+    items
+        |> List.map (renderEntry renderConfig)
+        |> Element.column
+            [ Element.width <| Element.px 200
+            , Element.height Element.fill
+            , Element.padding 4
+            , Element.alignRight
+            , Background.color <| Element.rgb 255 255 255
+            , Palette.toBorderColor <| Palette.gray200
+            , Border.width 1
+            , Border.rounded 4
+            , shadow 16
+            , shadow 80
+            ]
+        |> Element.el
+            [ Element.none
+                |> Element.el
+                    [ Element.htmlAttribute <| HtmlAttrs.style "position" "fixed"
+                    , Element.htmlAttribute <| HtmlAttrs.style "top" "0"
+                    , Element.htmlAttribute <| HtmlAttrs.style "left" "0"
+                    , Element.htmlAttribute <| HtmlAttrs.style "width" "100vw"
+                    , Element.htmlAttribute <| HtmlAttrs.style "height" "100vh"
+                    , Events.onClick onToggle
+                    ]
+                |> Element.behindContent
+            , Element.width Element.fill
+            , Element.height Element.fill
+            ]
+
+
+renderEntry : RenderConfig -> MenuItem msg -> Element msg
+renderEntry renderConfig (MenuItem menuItem) =
+    Element.row
+        (Element.padding 8
+            :: Element.alignTop
+            :: Element.spacing 5
+            :: Element.width Element.fill
+            :: Events.onClick menuItem.onClick
+            :: Element.mouseOver
+                [ Palette.toBackgroundColor Palette.gray300 ]
+            :: Border.rounded 3
+            :: ARIA.toElementAttributes ARIA.roleButton
+        )
+        [ case menuItem.icon of
+            Just icon ->
+                menuItem.title
+                    |> icon
+                    |> Icon.withSize Size.extraSmall
+                    |> Icon.withColor (Maybe.withDefault Palette.blue menuItem.color)
+                    |> Icon.renderElement renderConfig
+                    |> Element.el [ Element.alignTop ]
+
+            Nothing ->
+                Element.none
+        , Text.body2 menuItem.title
+            |> Text.withColor (Maybe.withDefault Palette.blue menuItem.color)
+            |> Text.renderElement renderConfig
+        ]

--- a/src/UI/Menu.elm
+++ b/src/UI/Menu.elm
@@ -17,7 +17,6 @@ A menu can be created and rendered as in the following pipeline:
             [ Menu.item Download
                 { icon = Icon.download
                 , title = "Download"
-                , color = Nothing
                 }
             ]
         |> Menu.renderElement renderConfig

--- a/src/UI/Menu.elm
+++ b/src/UI/Menu.elm
@@ -130,11 +130,11 @@ itemWithColor color (MenuItem menuItem) =
         |> Menu.renderElement renderConfig
 
 -}
-menu : msg -> Button msg -> Menu msg
-menu onToggle button =
+menu : msg -> List (MenuItem msg) -> Button msg -> Menu msg
+menu onToggle items button =
     Menu
         { button = button
-        , items = []
+        , items = items
         , onToggle = onToggle
         , isVisible = False
         }

--- a/src/UI/Menu.elm
+++ b/src/UI/Menu.elm
@@ -1,4 +1,10 @@
-module UI.Menu exposing (Menu, MenuItem, item, menu, setVisible, renderElement)
+module UI.Menu exposing
+    ( Menu, item, menu
+    , itemWithColor
+    , setVisible
+    , renderElement
+    , MenuItem
+    )
 
 {-| The `UI.Menu` is a component for rendering dropdown menus.
 
@@ -16,9 +22,16 @@ A menu can be created and rendered as in the following pipeline:
             ]
         |> Menu.renderElement renderConfig
 
+
 # Building
 
 @docs Menu, item, menu
+
+
+# Style
+
+@docs itemWithColor
+
 
 # Interactive
 
@@ -30,6 +43,7 @@ A menu can be created and rendered as in the following pipeline:
 @docs renderElement
 
 -}
+
 import Element exposing (Element)
 import Element.Background as Background
 import Element.Border as Border
@@ -43,6 +57,7 @@ import UI.Size as Size
 import UI.Text as Text
 import UI.Utils.ARIA as ARIA
 
+
 type alias Properties msg =
     { button : Button msg
     , items : List (MenuItem msg)
@@ -50,10 +65,12 @@ type alias Properties msg =
     , isVisible : Bool
     }
 
+
 {-| The `Menu msg` type is used for describing the component for later rendering.
 -}
 type Menu msg
     = Menu (Properties msg)
+
 
 {-| The `MenuItem` is required when assembling the list of menu entries.
 -}
@@ -76,24 +93,32 @@ type alias InternalMenuItem msg =
             [ Menu.item Download
                 { icon = Icon.download
                 , title = "Download"
-                , color = Nothing
                 }
             ]
         |> Menu.renderElement renderConfig
 
 -}
-item :
-    msg
-    ->
-        { icon : Maybe (String -> Icon)
-        , title : String
-        , color : Maybe Color
-        }
-    -> MenuItem msg
-item onToggle { icon, title, color } =
-    MenuItem { onClick = onToggle, icon = icon, title = title, color = color }
+item : msg -> { icon : Maybe (String -> Icon), title : String } -> MenuItem msg
+item onToggle { icon, title } =
+    MenuItem { onClick = onToggle, icon = icon, title = title, color = Nothing }
 
 
+{-| Sets the color of a `MenuItem`.
+
+    Button.cmd ToggleMenu Button.primary
+        |> Menu.menu ToggleMenu
+            [ Menu.item Delete
+                { icon = Icon.delete
+                , title = "Delete"
+                }
+                |> Menu.itemWithColor Palette.red700
+            ]
+        |> Menu.renderElement renderConfig
+
+-}
+itemWithColor : Color -> MenuItem msg -> MenuItem msg
+itemWithColor color (MenuItem menuItem) =
+    MenuItem { menuItem | color = Just color }
 
 
 {-| Defines all the required properties for creating a dropdown menu.
@@ -103,13 +128,12 @@ item onToggle { icon, title, color } =
             [ Menu.item Download
                 { icon = Just Icon.download
                 , title = "Download"
-                , color = Nothing
                 }
             , Menu.item Delete
                 { icon = Just Icon.delete
                 , title = "Delete"
-                , color = Just Palette.red700
                 }
+                |> Menu.itemWithColor Palette.red700
             ]
         |> Menu.renderElement renderConfig
 
@@ -157,9 +181,8 @@ renderElement renderConfig (Menu { button, items, onToggle, isVisible }) =
             )
 
 
+
 -- Internals
-
-
 
 
 renderMenu : RenderConfig -> List (MenuItem msg) -> msg -> Element msg

--- a/yarn.lock
+++ b/yarn.lock
@@ -2734,10 +2734,10 @@ cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
-cypress@^9.0.0:
-  version "9.1.1"
-  resolved "https://registry.npmjs.org/cypress/-/cypress-9.1.1.tgz"
-  integrity sha512-yWcYD8SEQ8F3okFbRPqSDj5V0xhrZBT5QRIH+P1J2vYvtEmZ4KGciHE7LCcZZLILOrs7pg4WNCqkj/XRvReQlQ==
+cypress@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-9.2.0.tgz#727c20b4662167890db81d5f6ba615231835b17d"
+  integrity sha512-Jn26Tprhfzh/a66Sdj9SoaYlnNX6Mjfmj5PHu2a7l3YHXhrgmavM368wjCmgrxC6KHTOv9SpMQGhAJn+upDViA==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
#### :thinking: What?

Ports `PopupMenu` from `wms-web` into a more stable `Menu` component.

#### :man_shrugging: Why?

Many apps are using context menu buttons, this component should fit all these uses.

#### :pushpin: Jira Issue

[WS-544](https://paacklogistics.atlassian.net/browse/WS-544)
[LMO-1407](https://paacklogistics.atlassian.net/browse/LMO-1407)

#### :no_good: Blocked by

Nothing.

#### :clipboard: Pending

- Nothing

### :fire: Extra

Screenshots

![image](https://user-images.githubusercontent.com/2013206/147935381-e5844160-5d3f-41f6-a338-2b4bb3dfc345.png)

![image](https://user-images.githubusercontent.com/2013206/147935424-90754b19-38f9-4287-8a44-5ec82a43a73a.png)
