### PR TITLE
S4S-377 | Add withId for button component

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "7.11.0",
+    "version": "7.12.0",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",

--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -487,7 +487,6 @@ toggleView cfg hint toggleMsg current { size, id } =
         attrs =
             Primitives.roundedBorders size
                 :: (Element.onIndividualClick <| toggleMsg (not current))
-                :: (id |> Maybe.map ElementUtils.id |> Maybe.withDefault (Primitives.roundedBorders size))
                 :: (ARIA.toElementAttributes <| ARIA.roleToggleButton current)
                 ++ toggleTheme current
                 ++ iconLayout hint size
@@ -495,7 +494,7 @@ toggleView cfg hint toggleMsg current { size, id } =
     Icon.toggle hint
         |> fromIcon
         |> bodyToElement cfg size
-        |> Element.el attrs
+        |> Element.el (prependMaybe (Maybe.map ElementUtils.id id) attrs)
 
 
 hyperlinkView :
@@ -515,19 +514,21 @@ hyperlinkView cfg body action { width, id, size } =
                 :: Font.regular
                 :: Font.underline
                 :: Element.pointer
-                :: (id |> Maybe.map ElementUtils.id |> Maybe.withDefault Element.pointer)
                 :: (ARIA.toElementAttributes <| ARIA.roleButton)
+
+        attrsWithId =
+            prependMaybe (Maybe.map ElementUtils.id id) attrs
     in
     case action of
         ActionRedirect link ->
             body
                 |> bodyToElement cfg size
-                |> Link.wrapElement cfg attrs link
+                |> Link.wrapElement cfg attrsWithId link
 
         ActionMsg msg ->
             body
                 |> bodyToElement cfg size
-                |> Element.el (Element.onIndividualClick msg :: attrs)
+                |> Element.el (Element.onIndividualClick msg :: attrsWithId)
 
 
 workingView :
@@ -544,21 +545,23 @@ workingView cfg tone body action { size, width, id } =
                 :: buttonWidth width
                 :: Font.semiBold
                 :: Element.pointer
-                :: (id |> Maybe.map ElementUtils.id |> Maybe.withDefault Element.pointer)
                 :: (ARIA.toElementAttributes <| ARIA.roleButton)
                 ++ workingTheme tone
                 ++ bodyAttrs body size
+
+        attrsWithId =
+            prependMaybe (Maybe.map ElementUtils.id id) attrs
     in
     case action of
         ActionRedirect link ->
             body
                 |> bodyToElement cfg size
-                |> Link.wrapElement cfg attrs link
+                |> Link.wrapElement cfg attrsWithId link
 
         ActionMsg msg ->
             body
                 |> bodyToElement cfg size
-                |> Element.el (Element.onIndividualClick msg :: attrs)
+                |> Element.el (Element.onIndividualClick msg :: attrsWithId)
 
 
 staticView :
@@ -573,14 +576,13 @@ staticView cfg body theme { size, width, id } =
             Primitives.roundedBorders size
                 :: buttonWidth width
                 :: Font.semiBold
-                :: (id |> Maybe.map ElementUtils.id |> Maybe.withDefault Font.semiBold)
                 :: Element.disabled
                 ++ bodyAttrs body size
                 ++ theme
     in
     body
         |> bodyToElement cfg size
-        |> Element.el attrs
+        |> Element.el (prependMaybe (Maybe.map ElementUtils.id id) attrs)
 
 
 

--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -152,7 +152,7 @@ defaultOptions : Options
 defaultOptions =
     { width = WidthShrink
     , size = Size.default
-    , id = ""
+    , id = Nothing
     }
 
 
@@ -329,8 +329,11 @@ withSize size button =
 
 
 {-| With `Button.withId`, you can add an [HTML ID attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id) to the button element.
+
+    Button.withId (Just "id") someButton
+
 -}
-withId : String -> Button msg -> Button msg
+withId : Maybe String -> Button msg -> Button msg
 withId id button =
     case button of
         Button prop opt ->
@@ -484,7 +487,7 @@ toggleView cfg hint toggleMsg current { size, id } =
         attrs =
             Primitives.roundedBorders size
                 :: (Element.onIndividualClick <| toggleMsg (not current))
-                :: ElementUtils.id id
+                :: (id |> Maybe.map ElementUtils.id |> Maybe.withDefault (Primitives.roundedBorders size))
                 :: (ARIA.toElementAttributes <| ARIA.roleToggleButton current)
                 ++ toggleTheme current
                 ++ iconLayout hint size
@@ -512,7 +515,7 @@ hyperlinkView cfg body action { width, id, size } =
                 :: Font.regular
                 :: Font.underline
                 :: Element.pointer
-                :: ElementUtils.id id
+                :: (id |> Maybe.map ElementUtils.id |> Maybe.withDefault Element.pointer)
                 :: (ARIA.toElementAttributes <| ARIA.roleButton)
     in
     case action of
@@ -541,7 +544,7 @@ workingView cfg tone body action { size, width, id } =
                 :: buttonWidth width
                 :: Font.semiBold
                 :: Element.pointer
-                :: ElementUtils.id id
+                :: (id |> Maybe.map ElementUtils.id |> Maybe.withDefault Element.pointer)
                 :: (ARIA.toElementAttributes <| ARIA.roleButton)
                 ++ workingTheme tone
                 ++ bodyAttrs body size
@@ -570,7 +573,7 @@ staticView cfg body theme { size, width, id } =
             Primitives.roundedBorders size
                 :: buttonWidth width
                 :: Font.semiBold
-                :: ElementUtils.id id
+                :: (id |> Maybe.map ElementUtils.id |> Maybe.withDefault Font.semiBold)
                 :: Element.disabled
                 ++ bodyAttrs body size
                 ++ theme

--- a/src/UI/Internal/Button.elm
+++ b/src/UI/Internal/Button.elm
@@ -23,7 +23,7 @@ import UI.RenderConfig exposing (RenderConfig)
 type alias Options =
     { width : ButtonWidth
     , size : Size
-    , id : String
+    , id : Maybe String
     }
 
 

--- a/src/UI/Internal/Button.elm
+++ b/src/UI/Internal/Button.elm
@@ -23,6 +23,7 @@ import UI.RenderConfig exposing (RenderConfig)
 type alias Options =
     { width : ButtonWidth
     , size : Size
+    , id : String
     }
 
 


### PR DESCRIPTION
#### :thinking: What?

Adds the ability to add an ID to button component

#### :man_shrugging: Why?

Our squad [need it](https://paacklogistics.atlassian.net/browse/S4S-377) to track clicks on buttons in Timeslot-change page through Google Tag Manager. Here is a small [slack conversation](https://paack.slack.com/archives/CUKQCEN30/p1643367475526139) to have more context.

#### :pushpin: Jira Issue

Not tracked.
