### PR TITLE
WS-564 | Paginator scroll

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "PaackEng/paack-ui",
     "summary": "Paack's Design System applied over Elm UI",
     "license": "BSD-3-Clause",
-    "version": "7.16.0",
+    "version": "7.17.0",
     "exposed-modules": [
         "UI.Alert",
         "UI.Analytics",

--- a/showcase/src/Tables/Stories.elm
+++ b/showcase/src/Tables/Stories.elm
@@ -102,6 +102,7 @@ demoTable renderConfig columns state msg =
             , toCover = Book.toTableCover
             }
         |> Stateful.withWidth Element.shrink
+        |> Stateful.withHeight (Element.px 480)
         |> Stateful.renderElement renderConfig
 
 

--- a/showcase/src/Tables/Stories.elm
+++ b/showcase/src/Tables/Stories.elm
@@ -101,7 +101,7 @@ demoTable renderConfig columns state msg =
             { toDetails = Book.toTableDetails
             , toCover = Book.toTableCover
             }
-        |> Stateful.withWidth Element.shrink
+        |> Stateful.withWidth (Element.px 800)
         |> Stateful.withHeight (Element.px 480)
         |> Stateful.renderElement renderConfig
 

--- a/src/UI/Internal/Tables/Paginator.elm
+++ b/src/UI/Internal/Tables/Paginator.elm
@@ -131,7 +131,8 @@ rangeInfo renderConfig (Paginator { totalAmount } { index, amountByPage }) =
         |> Text.body2
         |> Text.withOverflow Text.wrap
         |> Text.renderElement renderConfig
-        |> Element.el [ Element.width <| Element.minimum 96 Element.shrink ]
+        |> Element.el
+            [ Element.width <| Element.minimum 132 Element.shrink ]
         |> Tuple.pair "range-info"
 
 

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -1387,21 +1387,15 @@ desktopView renderConfig prop opt =
         items =
             viewGetItems state opt
 
-        ( items_, footer ) =
+        items_ =
             case state.paginator of
-                Just ({ from, by } as paginator) ->
-                    ( items
+                Just { from, by } ->
+                    items
                         |> List.drop from
                         |> List.take by
-                    , paginator
-                        |> viewPaginator renderConfig (List.length items)
-                        |> Element.map prop.toExternalMsg
-                        |> Tuple.pair "paginator"
-                        |> List.singleton
-                    )
 
                 Nothing ->
-                    ( items, [] )
+                    items
 
         rows =
             List.map (rowWithSelection renderConfig prop.toExternalMsg state prop.toRow columns) items_
@@ -1421,12 +1415,38 @@ desktopView renderConfig prop opt =
                 columns
                 selectionHeader
     in
-    Keyed.column
-        [ Element.spacing 2
-        , Element.width opt.width
-        , Element.paddingEach padding
-        ]
-        (headers :: rows ++ footer)
+    case state.paginator of
+        Just paginator ->
+            Keyed.column
+                [ Element.width opt.width
+                , Element.height Element.fill
+                , Element.paddingEach padding
+                ]
+                [ (headers :: rows)
+                    |> Keyed.column
+                        [ Element.spacing 2
+                        , Element.width Element.fill
+                        , Element.height Element.fill
+                        , Element.scrollbars
+                        ]
+                    |> Element.el
+                        [ Element.width Element.fill
+                        , Element.height Element.fill
+                        ]
+                    |> Tuple.pair "table"
+                , paginator
+                    |> viewPaginator renderConfig (List.length items)
+                    |> Element.map prop.toExternalMsg
+                    |> Tuple.pair "paginator"
+                ]
+
+        Nothing ->
+            Keyed.column
+                [ Element.spacing 2
+                , Element.width opt.width
+                , Element.paddingEach padding
+                ]
+                (headers :: rows)
 
 
 viewPaginator : RenderConfig -> Int -> PaginatorState -> Element (Msg item)

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -187,7 +187,6 @@ import UI.Internal.Tables.ListView as ListView
 import UI.Internal.Tables.Paginator as Paginator
 import UI.Internal.Tables.Sorters as Sorters exposing (Sorters)
 import UI.Internal.Tables.View exposing (..)
-import UI.Palette as Palette
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
 import UI.Tables.Common as Common exposing (..)
 import UI.Utils.TypeNumbers as T

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -12,7 +12,7 @@ module UI.Tables.Stateful exposing
     , Sorters, stateWithSorters
     , sortersEmpty, sortBy, sortByFloat, sortByInt, sortByChar, sortWith, unsortable
     , sortDecreasing, sortIncreasing
-    , withWidth
+    , withWidth, withHeight
     , stateWithSelection, stateIsSelected
     , renderElement
     )
@@ -144,9 +144,9 @@ And on model:
 @docs sortDecreasing, sortIncreasing
 
 
-# Width
+# Size
 
-@docs withWidth
+@docs withWidth, withHeight
 
 
 # Selection
@@ -187,6 +187,7 @@ import UI.Internal.Tables.ListView as ListView
 import UI.Internal.Tables.Paginator as Paginator
 import UI.Internal.Tables.Sorters as Sorters exposing (Sorters)
 import UI.Internal.Tables.View exposing (..)
+import UI.Palette as Palette
 import UI.RenderConfig as RenderConfig exposing (RenderConfig)
 import UI.Tables.Common as Common exposing (..)
 import UI.Utils.TypeNumbers as T
@@ -225,6 +226,7 @@ type alias StatefulConfig msg item columns =
 type alias Options msg item columns =
     { overwriteItems : Maybe (List item)
     , width : Element.Length
+    , height : Element.Length
     , responsive : Maybe (Responsive msg item columns)
     }
 
@@ -249,6 +251,7 @@ defaultOptions : Options msg item columns
 defaultOptions =
     { overwriteItems = Nothing
     , width = shrink
+    , height = fill
     , responsive = Nothing
     }
 
@@ -1128,6 +1131,18 @@ withWidth width (Table prop opt_) =
     Table prop { opt_ | width = width }
 
 
+{-| Applies [`Element.height`](/packages/mdgriffith/elm-ui/latest/Element#height) to the component.
+
+    Table.withHeight
+        (Element.fill |> Element.minimum 220)
+        someTable
+
+-}
+withHeight : Element.Length -> StatefulTable msg item columns -> StatefulTable msg item columns
+withHeight height (Table prop opt_) =
+    Table prop { opt_ | height = height }
+
+
 
 -- Sorting
 
@@ -1419,24 +1434,23 @@ desktopView renderConfig prop opt =
         Just paginator ->
             Keyed.column
                 [ Element.width opt.width
-                , Element.height Element.fill
+                , Element.height opt.height
                 , Element.paddingEach padding
                 ]
-                [ (headers :: rows)
-                    |> Keyed.column
-                        [ Element.spacing 2
-                        , Element.width Element.fill
-                        , Element.height Element.fill
-                        , Element.scrollbars
-                        ]
-                    |> Element.el
-                        [ Element.width Element.fill
-                        , Element.height Element.fill
-                        ]
+                [ Keyed.column
+                    [ Element.spacing 2
+                    , Element.height Element.fill
+                    , Element.width Element.fill
+                    , Element.alignTop
+                    , Element.scrollbars
+                    ]
+                    (headers :: rows)
                     |> Tuple.pair "table"
                 , paginator
                     |> viewPaginator renderConfig (List.length items)
                     |> Element.map prop.toExternalMsg
+                    |> Element.el
+                        [ Element.alignBottom ]
                     |> Tuple.pair "paginator"
                 ]
 
@@ -1444,6 +1458,7 @@ desktopView renderConfig prop opt =
             Keyed.column
                 [ Element.spacing 2
                 , Element.width opt.width
+                , Element.height opt.height
                 , Element.paddingEach padding
                 ]
                 (headers :: rows)

--- a/src/UI/Tables/Stateful.elm
+++ b/src/UI/Tables/Stateful.elm
@@ -1450,7 +1450,9 @@ desktopView renderConfig prop opt =
                     |> viewPaginator renderConfig (List.length items)
                     |> Element.map prop.toExternalMsg
                     |> Element.el
-                        [ Element.alignBottom ]
+                        [ Element.alignBottom
+                        , Element.width Element.fill
+                        ]
                     |> Tuple.pair "paginator"
                 ]
 


### PR DESCRIPTION
#### :thinking: What?

- Adds `withHeight` to the stateful table.
- Adds a a scrollbar to the stateful tables that have a paginator.

#### :man_shrugging: Why?

Fixes a design issue on wms.

It unblocks first pending point on https://github.com/PaackEng/wms-web/pull/630

I don't think solving the second point is worth for now.

#### :pushpin: Jira Issue

[WS-564](https://paacklogistics.atlassian.net/browse/WS-564)

#### :no_good: Blocked by

Nothing.

#### :clipboard: Pending

Nothing.

### :fire: Extra

Already up and running on https://paackeng.github.io/paack-ui/#Complex%20components/Tables/Desktop