### PR TITLE
WS-659 | Allow changing the direction UI.Menu opens

### DIFF
--- a/src/UI/Internal/Tables/Paginator.elm
+++ b/src/UI/Internal/Tables/Paginator.elm
@@ -353,11 +353,12 @@ pageAmountSelector renderConfig paginator =
 
 amountMenu : RenderConfig -> Paginator msg -> Element msg
 amountMenu renderConfig (Paginator prop opt) =
-    Button.fromLabeledOnLeftIcon (Icon.chevronDown <| String.fromInt opt.amountByPage)
+    Button.fromLabeledOnLeftIcon (Icon.chevronUp <| String.fromInt opt.amountByPage)
         |> Button.cmd prop.onToggleMenu Button.light
         |> Button.withSize Size.extraSmall
         |> Menu.menu prop.onToggleMenu
             (List.map (amountMenuItem prop.onChangeAmountByPage) opt.pageAmountOptions)
+        |> Menu.withOpenDirection Menu.openAbove
         |> Menu.setVisible (menuIsVisible prop.state)
         |> Menu.renderElement renderConfig
 


### PR DESCRIPTION
#### :thinking: What?

WS-659 | Allow changing the direction UI.Menu opens to.

#### :man_shrugging: Why?

You can't change the amount of entries in a fullscreen table.

#### :pushpin: Jira Issue

[WS-659](https://paacklogistics.atlassian.net/browse/WS-659)

#### :no_good: Blocked by

Nothing.

#### :clipboard: Pending

- [x] Nothing

### :fire: Extra

Nothing.
